### PR TITLE
Add integrity checks and display for AutoGather

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -122,6 +122,8 @@ namespace GatherBuddy.AutoGather
             var textNode = gatheringMasterpiece->AtkUnitBase.GetTextNodeById(47);
             var text     = textNode->NodeText.ToString();
 
+            var integrityNode = gatheringMasterpiece->AtkUnitBase.GetTextNodeById(126);
+            var integrityText = integrityNode->NodeText.ToString();
 
             if (!int.TryParse(text, out var collectibility))
             {
@@ -129,23 +131,30 @@ namespace GatherBuddy.AutoGather
                 //Communicator.Print("Parsing failed, item is not collectable.");
             }
 
+            if (!int.TryParse(integrityText, out var integrity))
+            {
+                collectibility = 99999;
+                integrity      = 99999;
+            }
+
             if (collectibility < 99999)
             {
                 LastCollectability = collectibility;
-                if (ShouldUseScrutiny(collectibility))
+                LastIntegrity      = integrity;
+                if (ShouldUseScrutiny(collectibility, integrity))
                     TaskManager.Enqueue(() => UseAction(Actions.Scrutiny));
-                if (ShouldUseMeticulous(collectibility))
+                if (ShouldUseMeticulous(collectibility, integrity))
                     TaskManager.Enqueue(() => UseAction((Actions.Meticulous)));
-                if (ShouldUseSolidAge(collectibility))
+                if (ShouldUseSolidAge(collectibility, integrity))
                     TaskManager.Enqueue(() => UseAction(Actions.SolidAge));
-                if (ShouldUseWise(collectibility))
+                if (ShouldUseWise(collectibility, integrity))
                     TaskManager.Enqueue(() => UseAction((Actions.Wise)));
-                if (ShouldCollect(collectibility))
+                if (ShouldCollect(collectibility, integrity))
                     TaskManager.Enqueue(() => UseAction(Actions.Collect));
             }
         }
 
-        private bool ShouldUseWise(int collectability)
+        private bool ShouldUseWise(int collectability, int integrity)
         {
             if (Player.Level < Actions.Wise.MinLevel)
                 return false;
@@ -154,7 +163,7 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.WiseConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.WiseConfig.MaximumGP)
                 return false;
-            if (collectability == 1000 && Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765))
+            if (collectability == 1000 && Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765) && integrity < 4)
             {
                 return true;
             }
@@ -162,7 +171,7 @@ namespace GatherBuddy.AutoGather
             return false;
         }
 
-        private bool ShouldCollect(int collectability)
+        private bool ShouldCollect(int collectability, int integrity)
         {
             if (Player.Level < Actions.Collect.MinLevel)
                 return false;
@@ -171,13 +180,13 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.CollectConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.CollectConfig.MaximumGP)
                 return false;
-            if (collectability == 1000)
+            if (collectability == 1000 && integrity > 0)
                 return true;
 
             return false;
         }
 
-        private bool ShouldUseMeticulous(int collectability)
+        private bool ShouldUseMeticulous(int collectability, int integrity)
         {
             if (Player.Level < Actions.Meticulous.MinLevel)
                 return false;
@@ -186,13 +195,13 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MaximumGP)
                 return false;
-            if (collectability < 1000)
+            if (collectability < 1000 && integrity >= 1)
                 return true;
 
             return false;
         }
 
-        private bool ShouldUseScrutiny(int collectability)
+        private bool ShouldUseScrutiny(int collectability, int integrity)
         {
             if (Player.Level < Actions.Scrutiny.MinLevel)
                 return false;
@@ -201,13 +210,13 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.MaximumGP)
                 return false;
-            if (collectability < 800)
+            if (collectability < 800 && integrity > 2)
                 return true;
 
             return false;
         }
 
-        private bool ShouldUseSolidAge(int collectability)
+        private bool ShouldUseSolidAge(int collectability, int integrity)
         {
             if (Player.Level < Actions.SolidAge.MinLevel)
                 return false;
@@ -216,7 +225,7 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MaximumGP)
                 return false;
-            if (collectability == 1000)
+            if (collectability == 1000 && integrity < 4)
                 return true;
 
             return false;

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -49,6 +49,8 @@ namespace GatherBuddy.AutoGather
                 gatheringWindow->GatheredItemId8,
             };
             var itemIndex = GetIndexOfItemToClick(ids, item);
+            if (itemIndex < 0)
+                itemIndex = ids.FindIndex(i => i > 0);
 
             var receiveEventAddress = new nint(gatheringWindow->AtkUnitBase.AtkEventListener.vfunc[2]);
             var eventDelegate       = Marshal.GetDelegateForFunctionPointer<ReceiveEventDelegate>(receiveEventAddress);

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -10,8 +10,10 @@ using System.Linq;
 using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
+using Dalamud.Interface.Colors;
 using Dalamud.Interface.Windowing;
 using FFXIVClientStructs.FFXIV.Client.UI;
+using OtterGui.Raii;
 
 namespace GatherBuddy.AutoGather
 {
@@ -39,6 +41,7 @@ namespace GatherBuddy.AutoGather
             {
                 ImGui.Text($"GBR Collectable Replacement Window");
                 ImGui.Text($"Collectable Score: {GatherBuddy.AutoGather.LastCollectability}");
+                ImGui.Text($"Integrity: {GatherBuddy.AutoGather.LastIntegrity}/4");
             }
         }
         private static bool _gatherDebug;
@@ -52,6 +55,12 @@ namespace GatherBuddy.AutoGather
             ImGui.Text($"Status: {GatherBuddy.AutoGather.AutoStatus}");
             var lastNavString = GatherBuddy.AutoGather.LastNavigationResult.HasValue ? GatherBuddy.AutoGather.LastNavigationResult.Value ? "Successful" : "Failed (If you're seeing this you probably need to restart your game)" : "None";
             ImGui.Text($"Navigation: {lastNavString}");
+            if (GatherBuddy.AutoGather.ItemsToGatherInZone.Count() > 1)
+            {
+                using var color = ImRaii.PushColor(ImGuiCol.Text, ImGuiColors.DalamudRed);
+                ImGui.Text($"WARNING: There is more than 1 desired item in the zone. GBR may behave unexpectedly.");
+                color.Pop();
+            }
         }
         
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -105,6 +105,7 @@ namespace GatherBuddy.AutoGather
         }
         public string AutoStatus { get; set; } = "Idle";
         public int    LastCollectability = 0;
+        public int    LastIntegrity      = 0;
         public Dictionary<uint, List<Vector3>> DesiredNodesInZone
         {
             get

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -24,7 +24,35 @@ namespace GatherBuddy.AutoGather
         private GatherBuddy _plugin;
 
         public TaskManager TaskManager { get; }
-        public bool Enabled { get; set; } = false;
+
+        private bool _enabled { get; set; } = false;
+
+        public unsafe bool Enabled
+        {
+            get => _enabled;
+            set
+            {
+                if (!value)
+                {
+                    //Do Reset Tasks
+                    var gatheringMasterpiece = (AddonGatheringMasterpiece*)Dalamud.GameGui.GetAddonByName("GatheringMasterpiece", 1);
+                    if (gatheringMasterpiece != null && !gatheringMasterpiece->AtkUnitBase.IsVisible)
+                    {
+                        gatheringMasterpiece->AtkUnitBase.IsVisible = true;
+                    }
+
+                    if (IsPathing || IsPathGenerating)
+                    {
+                        VNavmesh_IPCSubscriber.Path_Stop();
+                    }
+
+                    HasSeenFlag    = false;
+                    HiddenRevealed = false;
+                }
+
+                _enabled = value;
+            }
+        }
 
         public unsafe void DoAutoGather()
         {
@@ -45,20 +73,6 @@ namespace GatherBuddy.AutoGather
             if (!Enabled)
             {
                 AutoStatus = "Not running...";
-                //Do Reset Tasks
-                var gatheringMasterpiece = (AddonGatheringMasterpiece*)Dalamud.GameGui.GetAddonByName("GatheringMasterpiece", 1);
-                if (gatheringMasterpiece != null && !gatheringMasterpiece->AtkUnitBase.IsVisible)
-                {
-                    gatheringMasterpiece->AtkUnitBase.IsVisible = true;
-                }
-
-                if (IsPathing || IsPathGenerating)
-                {
-                    VNavmesh_IPCSubscriber.Path_Stop();
-                }
-
-                HasSeenFlag    = false;
-                HiddenRevealed = false;
                 return;
             }
             if (TaskManager.NumQueuedTasks > 0)

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -587,6 +587,8 @@ public partial class Interface
         ImGui.Text($"ItemsToGather: {GatherBuddy.AutoGather.ItemsToGather.Count()}");
         ImGui.Text($"ShouldUseFlag: {GatherBuddy.AutoGather.ShouldUseFlag}");
         ImGui.Text(($"HasSeenFlag: {GatherBuddy.AutoGather.HasSeenFlag}"));
+        ImGui.Text($"LastIntegrity: {GatherBuddy.AutoGather.LastIntegrity}");
+        ImGui.Text($"LastCollectScore: {GatherBuddy.AutoGather.LastCollectability}");
         
         if (ImGui.CollapsingHeader("Item Priority (Current Zone)"))
         {


### PR DESCRIPTION
Extra display lines have been added to show item integrity in the debug and UI windows. The collectability-based function calls have been updated to also evaluate integrity before taking an action. Also, measures have been taken to prevent possible issues when more than one desired item is in the Zone.