### PR TITLE
Refactor code and fix movement bug in AutoGather feature

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -45,7 +45,8 @@ namespace GatherBuddy.AutoGather
                     {
                         VNavmesh_IPCSubscriber.Path_Stop();
                     }
-
+                    
+                    TaskManager.Abort();
                     HasSeenFlag    = false;
                     HiddenRevealed = false;
                     AutoStatus     = "Idle...";
@@ -111,12 +112,6 @@ namespace GatherBuddy.AutoGather
             }
             else if (ValidNodesInRange.Any())
             {
-                if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForGathering)
-                {
-                    AutoStatus = "Waiting for GP to regenerate...";
-                    return;
-                }
-                AutoStatus = "Moving to node...";
                 HiddenRevealed = false;
                 TaskManager.Enqueue(MoveToCloseNode);
             }

--- a/GatherBuddy/CustomInfo/FuzzyVector3.cs
+++ b/GatherBuddy/CustomInfo/FuzzyVector3.cs
@@ -42,7 +42,7 @@ namespace GatherBuddy.CustomInfo
             catch (Exception)
             {
                 GatherBuddy.Log.Debug("Failed to correct for mesh, returning original vector.");
-                return vector.Fuzz();
+                return vector;
             }
         }
 


### PR DESCRIPTION
The code has been refactored by adding throttle checks to various parts to prevent them from being executed too frequently. A bug in the AutoGather feature that caused the character to move before the required GP had fully regenerated has been fixed. This bug was causing a failed gathering attempt, now the character will wait till the required GP regenerates.