### PR TITLE
Added collectible gathering on the last integrity point

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -182,7 +182,10 @@ namespace GatherBuddy.AutoGather
                     if (LastIntegrity == 1  
                      && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
                      && LastCollectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility)
+                    {
                         TaskManager.Enqueue(() => UseAction(Actions.Collect));
+                        return;
+                    }
 
                     if (ShouldUseScrutiny(collectibility, integrity))
                         TaskManager.Enqueue(() => UseAction(Actions.Scrutiny));

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -177,6 +177,13 @@ namespace GatherBuddy.AutoGather
                 {
                     LastCollectability = collectibility;
                     LastIntegrity      = integrity;
+
+                    // Check if we need to gather on the last integrity point
+                    if (LastIntegrity == 1  
+                     && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
+                     && LastCollectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility)
+                        TaskManager.Enqueue(() => UseAction(Actions.Collect));
+
                     if (ShouldUseScrutiny(collectibility, integrity))
                         TaskManager.Enqueue(() => UseAction(Actions.Scrutiny));
                     if (ShouldUseScour(collectibility, integrity))

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -13,25 +13,27 @@ namespace GatherBuddy.AutoGather
         public uint                            AutoGatherMountId             { get; set; } = 1;
         public Dictionary<uint, List<Vector3>> BlacklistedNodesByTerritoryId { get; set; } = new();
 
-        public ActionConfig BYIIConfig                 { get; set; } = new(true, 100, uint.MaxValue);
-        public ActionConfig LuckConfig                 { get; set; } = new(true, 200, uint.MaxValue);
-        public ActionConfig YieldIIConfig              { get; set; } = new(true, 500, uint.MaxValue);
-        public ActionConfig YieldIConfig               { get; set; } = new(true, 400, uint.MaxValue);
-        public ActionConfig ScrutinyConfig             { get; set; } = new(true, (uint)AutoGather.Actions.Scrutiny.GpCost, uint.MaxValue);
-        public ActionConfig MeticulousConfig           { get; set; } = new(true, (uint)AutoGather.Actions.Meticulous.GpCost, uint.MaxValue);
-        public ActionConfig SolidAgeConfig             { get; set; } = new(true, (uint)AutoGather.Actions.SolidAge.GpCost, uint.MaxValue);
-        public ActionConfig WiseConfig                 { get; set; } = new(true, (uint)AutoGather.Actions.Wise.GpCost, uint.MaxValue);
-        public ActionConfig CollectConfig              { get; set; } = new(true, (uint)AutoGather.Actions.Collect.GpCost, uint.MaxValue);
-        public ActionConfig ScourConfig                { get; set; } = new(true, (uint)AutoGather.Actions.Scour.GpCost, uint.MaxValue);
-        public int          TimedNodePrecog            { get; set; } = 120;
-        public bool         DoGathering                { get; set; } = true;
-        public uint         MinimumGPForGathering      { get; set; } = 0;
-        public float        NavResetCooldown           { get; set; } = 3.0f;
-        public float        NavResetThreshold          { get; set; } = 2.0f;
-        public bool         ForceWalking               { get; set; } = false;
-        public float        FarNodeFilterDistance      { get; set; } = 50.0f;
-        public bool         DisableFlagPathing         { get; set; } = false;
-        public uint         MinimumCollectibilityScore { get; set; } = 1000;
+        public ActionConfig BYIIConfig                                 { get; set; } = new(true, 100, uint.MaxValue);
+        public ActionConfig LuckConfig                                 { get; set; } = new(true, 200, uint.MaxValue);
+        public ActionConfig YieldIIConfig                              { get; set; } = new(true, 500, uint.MaxValue);
+        public ActionConfig YieldIConfig                               { get; set; } = new(true, 400, uint.MaxValue);
+        public ActionConfig ScrutinyConfig                             { get; set; } = new(true, (uint)AutoGather.Actions.Scrutiny.GpCost, uint.MaxValue);
+        public ActionConfig MeticulousConfig                           { get; set; } = new(true, (uint)AutoGather.Actions.Meticulous.GpCost, uint.MaxValue);
+        public ActionConfig SolidAgeConfig                             { get; set; } = new(true, (uint)AutoGather.Actions.SolidAge.GpCost, uint.MaxValue);
+        public ActionConfig WiseConfig                                 { get; set; } = new(true, (uint)AutoGather.Actions.Wise.GpCost, uint.MaxValue);
+        public ActionConfig CollectConfig                              { get; set; } = new(true, (uint)AutoGather.Actions.Collect.GpCost, uint.MaxValue);
+        public ActionConfig ScourConfig                                { get; set; } = new(true, (uint)AutoGather.Actions.Scour.GpCost, uint.MaxValue);
+        public int          TimedNodePrecog                            { get; set; } = 120;
+        public bool         DoGathering                                { get; set; } = true;
+        public uint         MinimumGPForGathering                      { get; set; } = 0;
+        public float        NavResetCooldown                           { get; set; } = 3.0f;
+        public float        NavResetThreshold                          { get; set; } = 2.0f;
+        public bool         ForceWalking                               { get; set; } = false;
+        public float        FarNodeFilterDistance                      { get; set; } = 50.0f;
+        public bool         DisableFlagPathing                         { get; set; } = false;
+        public uint         MinimumCollectibilityScore                 { get; set; } = 1000;
+        public bool         GatherIfLastIntegrity                      { get; set; } = false;
+        public uint         GatherIfLastIntegrityMinimumCollectibility { get; set; } = 600;
 
         public class ActionConfig
         {

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -87,8 +87,8 @@ public partial class Interface
 
         public static void DrawGatherIfLastIntegrity()
             => DrawCheckbox(
-                "Gather instead of losing the node",
-                "Will gather the node instead of losing it if the collectibility score hasn't been reached",
+                "Gather instead losing the node",
+                "Will gather the node instead losing it if the collectibility score hasn't been reached",
                 GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity,
                 b => GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity = b);
 

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -78,9 +78,26 @@ public partial class Interface
         public static void DrawMinimumCollectibilityScore()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore;
-            if (ImGui.DragInt("Minimum Collectibility Score", ref tmp, 1, 1000))
+            if (ImGui.DragInt("Collectibility score to reach before gathering", ref tmp, 1, 1, 1000))
             {
                 GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+
+        public static void DrawGatherIfLastIntegrity()
+            => DrawCheckbox(
+                "Gather instead of losing the node",
+                "Will gather the node instead of losing it if the collectibility score hasn't been reached",
+                GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity,
+                b => GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity = b);
+
+        public static void DrawGatherIfLastIntegrityMinimumCollectibility()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility;
+            if (ImGui.DragInt("Minimum collectibility score to reach before gathering on the last integrity point", ref tmp, 1, 1000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility = (uint)tmp;
                 GatherBuddy.Config.Save();
             }
         }
@@ -840,6 +857,11 @@ public partial class Interface
                 ConfigFunctions.DrawMountUpDistance();
                 ConfigFunctions.DrawMinimumGPGathering();
                 ConfigFunctions.DrawMinimumCollectibilityScore();
+                ConfigFunctions.DrawGatherIfLastIntegrity();
+
+                if (GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity)
+                    ConfigFunctions.DrawGatherIfLastIntegrityMinimumCollectibility();
+
                 ImGui.TreePop();
             }
 


### PR DESCRIPTION
Added two new options to the auto-gathering feature:

- Gather instead losing the node
- Minimum collectibility score to reach before gathering on the last integrity point

I also changed the "Minimum Collectibility Score" to "Collectibility score to reach before gathering" because I wasn't sure at first what it really meant.

The new feature let us chose to collect the node even if the selected collectible didn't reach the collectibility score that has been set. Optionally, we can set another minimum collectible value for this specific feature :

![image](https://github.com/user-attachments/assets/03d3da65-6344-444b-9ab7-30489a9e46eb)

![image](https://github.com/user-attachments/assets/bab39aec-1c63-4cde-a3f7-21b95506bb02)


_the second slider is hidden if the checkbox is unchecked_

In this example, if the collectible reached the score of 700 but only has one remaining integrity point, it will be gathered instead of trying to increase the value again and probably losing the node.

I hope everything is clear enough 😊