### PR TITLE
Fix Eureka Moment buff overwriting by Solid / Ageless

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -302,7 +302,7 @@ namespace GatherBuddy.AutoGather
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MaximumGP)
                 return false;
             if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-                && Dalamud.ClientState.LocalPlayer.StatusList.All(s => s.StatusId != 2765)
+                && !(Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765))
                 && integrity < 4)
                 return GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.UseAction;
 

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -301,7 +301,9 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MaximumGP)
                 return false;
-            if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore && integrity < 4)
+            if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                && Dalamud.ClientState.LocalPlayer.StatusList.All(s => s.StatusId != 2765)
+                && integrity < 4)
                 return GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.UseAction;
 
             return false;


### PR DESCRIPTION
For high GP collectible rotation where Solid / Ageless can be used multiple times, the current code prioritizes use Solid / Ageless despite having Eureka Moment buff active, causing wasted Wise actions. The code changes to ShouldUseSolidAge function now checks that Eureka Moment buff is inactive before using Solid / Ageless.