### PR TITLE
Bugfix/actions queuing

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -100,6 +100,7 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void DoActionTasks(Gatherable desiredItem)
         {
+            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
 
             if (GatheringAddon == null && MasterpieceAddon == null)
                 return;


### PR DESCRIPTION
- Added if / else statements in all gathering actions choices to avoid queuing 2 actions at the same time
- Removed Throttles
- Queued a wait for the end of the current gathering action to prevent calculating buffs and node values before the previous action was finished, which caused wrong actions being chosen.