### PR TITLE
Feature/use collectability fixed value

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -162,8 +162,7 @@ namespace GatherBuddy.AutoGather
                 {
                     MasterpieceAddon->AtkUnitBase.IsVisible = false;
                 }
-
-                var textNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(47);
+                var textNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(6);
                 var text     = textNode->NodeText.ToString();
 
                 var integrityNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(126);

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -157,11 +157,6 @@ namespace GatherBuddy.AutoGather
             {
                 if (MasterpieceAddon == null)
                     return;
-
-                if (MasterpieceAddon->AtkUnitBase.IsVisible)
-                {
-                    MasterpieceAddon->AtkUnitBase.IsVisible = false;
-                }
                 var textNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(6);
                 var text     = textNode->NodeText.ToString();
 


### PR DESCRIPTION
- Using node 6 instead of 47 for collectability value, avoiding value change on mouseover of the actions and having a fixed value instead of one moving over a few frames, possibly messing with calculations.
- Removed the hiding of the Collectable window as it's no longer required.