### PR TITLE
Improved the wait for gather action queuing

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -104,8 +104,6 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void DoActionTasks(Gatherable desiredItem)
         {
-            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
-
             if (GatheringAddon == null && MasterpieceAddon == null)
                 return;
 
@@ -143,14 +141,11 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void UseAction(Actions.BaseAction act)
         {
-            if (EzThrottler.Throttle($"Action: {act.Name}", 10))
+            var amInstance = ActionManager.Instance();
+            if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
             {
-                var amInstance = ActionManager.Instance();
-                if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
-                {
-                    amInstance->UseAction(ActionType.Action, act.ActionID);
-                    TaskManager.DelayNextImmediate(2500);
-                }
+                amInstance->UseAction(ActionType.Action, act.ActionID);
+                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -145,7 +145,8 @@ namespace GatherBuddy.AutoGather
             if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
             {
                 amInstance->UseAction(ActionType.Action, act.ActionID);
-                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
+                TaskManager.EnqueueImmediate(() => !Svc.Condition[ConditionFlag.Gathering42]);
+                TaskManager.Enqueue(() => Communicator.Print("Ready for next action."));
             }
         }
 


### PR DESCRIPTION
Slighly changed the placement of the wait for gathering action and used EnqueueImmediate to make sure we always wait for the action after it's used