### PR TITLE
Reworked the Collectables actions logic

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -121,6 +121,9 @@ namespace GatherBuddy.AutoGather
             {
                 TaskManager.Enqueue(() => DoGatherWindowTasks(desiredItem));
             }
+
+            if (MasterpieceAddon == null)
+                CurrentRotation = null;
         }
 
         private unsafe void DoGatherWindowActions(IGatherable? desiredItem)
@@ -158,6 +161,8 @@ namespace GatherBuddy.AutoGather
         {
             if (MasterpieceAddon == null)
                 return;
+            if (CurrentRotation == null)
+                CurrentRotation = new CollectableRotation(GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectableRotation);
 
             var textNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(6);
             var text     = textNode->NodeText.ToString();
@@ -168,7 +173,6 @@ namespace GatherBuddy.AutoGather
             if (!int.TryParse(text, out var collectibility))
             {
                 collectibility = 99999; // default value
-                //Communicator.Print("Parsing failed, item is not collectable.");
             }
 
             if (!int.TryParse(integrityText, out var integrity))
@@ -182,52 +186,11 @@ namespace GatherBuddy.AutoGather
                 LastCollectability = collectibility;
                 LastIntegrity      = integrity;
 
-                // Check if we need to gather on the last integrity point
-                if (LastIntegrity == 1
-                 && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
-                 && LastCollectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility)
-                {
-                    TaskManager.Enqueue(() => UseAction(Actions.Collect));
-                    return;
-                }
-
-                if (ShouldUseScrutiny(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction(Actions.Scrutiny));
-                else if (ShouldUseScour(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction(Actions.Scour));
-                else if (ShouldUseMeticulous(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction((Actions.Meticulous)));
-                else if (ShouldUseSolidAge(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction(Actions.SolidAge));
-                else if (ShouldUseWise(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction((Actions.Wise)));
-                else if (ShouldCollect(collectibility, integrity))
-                    TaskManager.Enqueue(() => UseAction(Actions.Collect));
+                TaskManager.Enqueue(() => UseAction(CurrentRotation.GetNextAction(MasterpieceAddon)));
             }
         }
 
-        private bool ShouldUseScour(int collectibility, int integrity)
-        {
-            if (Player.Level < Actions.Scour.MinLevel)
-                return false;
-            if (Player.Object.CurrentGp < Actions.Scour.GpCost)
-                return false;
-            if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.ScourConfig.MinimumGP
-             || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.ScourConfig.MaximumGP)
-                return false;
-
-            if (collectibility < GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-             && collectibility > GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore * 0.79
-             && !Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2418)
-             && integrity > 0)
-            {
-                return GatherBuddy.Config.AutoGatherConfig.ScourConfig.UseAction;
-            }
-
-            return false;
-        }
-
-        private bool ShouldUseWise(int collectability, int integrity)
+        private static bool ShouldUseWise()
         {
             if (Player.Level < Actions.Wise.MinLevel)
                 return false;
@@ -237,32 +200,13 @@ namespace GatherBuddy.AutoGather
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.WiseConfig.MaximumGP)
                 return false;
 
-            if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-             && Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765)
-             && integrity < 4)
-            {
+            if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765))
                 return GatherBuddy.Config.AutoGatherConfig.WiseConfig.UseAction;
-            }
 
             return false;
         }
 
-        private bool ShouldCollect(int collectability, int integrity)
-        {
-            if (Player.Level < Actions.Collect.MinLevel)
-                return false;
-            if (Player.Object.CurrentGp < Actions.Collect.GpCost)
-                return false;
-            if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.CollectConfig.MinimumGP
-             || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.CollectConfig.MaximumGP)
-                return false;
-            if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore && integrity > 0)
-                return GatherBuddy.Config.AutoGatherConfig.CollectConfig.UseAction;
-
-            return false;
-        }
-
-        private bool ShouldUseMeticulous(int collectability, int integrity)
+        private static bool ShouldUseMeticulous()
         {
             if (Player.Level < Actions.Meticulous.MinLevel)
                 return false;
@@ -271,16 +215,37 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MaximumGP)
                 return false;
-            if (collectability <= (GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore * 0.8)
-             && Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2418))
-                return GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction;
-            if (collectability < (GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore) && integrity > 0)
-                return GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction;
 
-            return false;
+            return GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction;
+        }
+        
+        private static bool ShouldUseScour()
+        {
+            if (Player.Level < Actions.Brazen.MinLevel)
+                return false;
+            if (Player.Object.CurrentGp < Actions.Brazen.GpCost)
+                return false;
+            if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.ScourConfig.MinimumGP
+             || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.ScourConfig.MaximumGP)
+                return false;
+
+            return GatherBuddy.Config.AutoGatherConfig.ScourConfig.UseAction;
+        }
+        
+        private static bool ShouldUseBrazen()
+        {
+            if (Player.Level < Actions.Meticulous.MinLevel)
+                return false;
+            if (Player.Object.CurrentGp < Actions.Meticulous.GpCost)
+                return false;
+            if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MinimumGP
+             || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MaximumGP)
+                return false;
+
+            return GatherBuddy.Config.AutoGatherConfig.BrazenConfig.UseAction;
         }
 
-        private bool ShouldUseScrutiny(int collectability, int integrity)
+        private static bool ShouldUseScrutiny()
         {
             if (Player.Level < Actions.Scrutiny.MinLevel)
                 return false;
@@ -289,15 +254,13 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.MaximumGP)
                 return false;
-            if (collectability < (GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore * 0.8)
-             && integrity > 2
-             && !Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 757))
+            if (!Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 757))
                 return GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.UseAction;
 
             return false;
         }
 
-        private bool ShouldUseSolidAge(int collectability, int integrity)
+        private static bool ShouldUseSolidAge(int integrity)
         {
             if (Player.Level < Actions.SolidAge.MinLevel)
                 return false;
@@ -306,8 +269,7 @@ namespace GatherBuddy.AutoGather
             if (Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MinimumGP
              || Player.Object.CurrentGp > GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.MaximumGP)
                 return false;
-            if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-             && !(Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765))
+            if (!(Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 2765))
              && integrity < 4)
                 return GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.UseAction;
 

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -1,0 +1,118 @@
+using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using System.Linq;
+
+namespace GatherBuddy.AutoGather
+{
+    public partial class AutoGather
+    {
+        private static CollectableRotation? CurrentRotation;
+        private unsafe class CollectableRotation
+        {
+            public CollectableRotation(uint GPToStart)
+            {
+                shouldUseFullRotation = Player.Object.CurrentGp >= GPToStart;
+            }
+            
+            private bool shouldUseFullRotation = false;
+            
+            public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
+                => shouldUseFullRotation ? FullRotation(MasterpieceAddon) : FillerRotation(MasterpieceAddon);
+
+            private Actions.BaseAction FullRotation(AddonGatheringMasterpiece* MasterpieceAddon)
+            {
+                int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
+                int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
+                int maxIntegrity     = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(129)->NodeText.ToString());
+                int scourColl        = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString().Substring(2));
+                int meticulousColl   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString().Substring(2));
+                int brazenColl       = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(93)->NodeText.ToString().Substring(2));
+                
+                if (currentIntegrity < maxIntegrity && ShouldUseWise())
+                    return Actions.Wise;
+                
+                if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore)
+                {
+                    if (currentIntegrity <= maxIntegrity
+                     && ShouldUseSolidAge(currentIntegrity))
+                        return Actions.SolidAge;
+                    
+                    return Actions.Collect;
+                }
+
+                if (currentIntegrity == 1
+                 && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
+                 && collectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility)
+                    return Actions.Collect;
+
+                if (NeedScrutiny(collectability, scourColl, meticulousColl, brazenColl) && ShouldUseScrutiny())
+                    return Actions.Scrutiny;
+
+                if (meticulousColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                 && ShouldUseMeticulous())
+                    return Actions.Meticulous;
+
+                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911)
+                 && brazenColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                 && ShouldUseBrazen())
+                    return Actions.Brazen;
+
+                if (scourColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                 && ShouldUseScour())
+                    return Actions.Scour;
+
+                if(ShouldUseMeticulous())
+                    return Actions.Meticulous;
+
+                return Actions.Scour;
+            }
+            
+            private Actions.BaseAction FillerRotation(AddonGatheringMasterpiece* MasterpieceAddon)
+            {
+                int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
+                int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
+                int scourColl        = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString().Substring(2));
+                int meticulousColl   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString().Substring(2));
+                
+                if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore)
+                    return Actions.Collect;
+
+                if (currentIntegrity == 1
+                 && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
+                 && collectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility)
+                    return Actions.Collect;
+
+                if (meticulousColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                 && ShouldUseMeticulous())
+                    return Actions.Meticulous;
+
+                if (scourColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
+                 && ShouldUseScour())
+                    return Actions.Scour;
+                
+                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911))
+                    return Actions.Brazen;
+
+                if(ShouldUseMeticulous())
+                    return Actions.Meticulous;
+
+                return Actions.Scour;
+            }
+
+            private bool NeedScrutiny(int collectability, int scourColl, int meticulousColl, int brazenColl)
+            {
+                uint collAim = GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore;
+                if (scourColl + collectability >= collAim)
+                    return false;
+                if (meticulousColl + collectability >= collAim)
+                    return false;
+                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911)
+                 && brazenColl + collectability >= collAim)
+                    return false;
+
+                return true;
+            }
+        }
+    }
+
+}

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -19,6 +19,7 @@ namespace GatherBuddy.AutoGather
         public ActionConfig YieldIConfig                               { get; set; } = new(true, 400, uint.MaxValue, new ActionConditions());
         public ActionConfig ScrutinyConfig                             { get; set; } = new(true, (uint)AutoGather.Actions.Scrutiny.GpCost, uint.MaxValue, new ActionConditions());
         public ActionConfig MeticulousConfig                           { get; set; } = new(true, (uint)AutoGather.Actions.Meticulous.GpCost, uint.MaxValue, new ActionConditions());
+        public ActionConfig BrazenConfig                               { get; set; } = new(true, (uint)AutoGather.Actions.Brazen.GpCost, uint.MaxValue, new ActionConditions());
         public ActionConfig SolidAgeConfig                             { get; set; } = new(true, (uint)AutoGather.Actions.SolidAge.GpCost, uint.MaxValue, new ActionConditions());
         public ActionConfig WiseConfig                                 { get; set; } = new(true, (uint)AutoGather.Actions.Wise.GpCost, uint.MaxValue, new ActionConditions());
         public ActionConfig CollectConfig                              { get; set; } = new(true, (uint)AutoGather.Actions.Collect.GpCost, uint.MaxValue, new ActionConditions());
@@ -26,6 +27,7 @@ namespace GatherBuddy.AutoGather
         public int          TimedNodePrecog                            { get; set; } = 20;
         public bool         DoGathering                                { get; set; } = true;
         public uint         MinimumGPForGathering                      { get; set; } = 0;
+        public uint         MinimumGPForCollectableRotation            { get; set; } = 700;
         public float        NavResetCooldown                           { get; set; } = 3.0f;
         public float        NavResetThreshold                          { get; set; } = 2.0f;
         public bool         ForceWalking                               { get; set; } = false;

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -78,6 +78,16 @@ public partial class Interface
                 GatherBuddy.Config.Save();
             }
         }
+        
+        public static void DrawMinimumGPCollectibleRotation()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectableRotation;
+            if (ImGui.DragInt("Minimum GP for using skills on collectibles", ref tmp, 1, 0, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectableRotation = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
 
         public static void DrawMinimumCollectibilityScore()
         {
@@ -291,6 +301,16 @@ public partial class Interface
                 GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction = b);
         
+        public static void DrawScourCheckbox()
+            => DrawCheckbox("Use Scour", "Use Scour to gather collectibles when appropriate",
+                GatherBuddy.Config.AutoGatherConfig.ScourConfig.UseAction,
+                b => GatherBuddy.Config.AutoGatherConfig.ScourConfig.UseAction = b);
+        
+        public static void DrawBrazenCheckbox()
+            => DrawCheckbox("Use Brazen", "Use Brazen to gather collectibles when appropriate",
+                GatherBuddy.Config.AutoGatherConfig.BrazenConfig.UseAction,
+                b => GatherBuddy.Config.AutoGatherConfig.BrazenConfig.UseAction = b);
+        
         public static void DrawSolidAgeCheckbox()
             => DrawCheckbox("Use Solid/Age", "Use Solid/Age to gather collectibles",
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeConfig.UseAction,
@@ -329,6 +349,26 @@ public partial class Interface
             if (ImGui.DragInt("Meticulous Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MaximumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+        
+        public static void DrawScourMaxGp()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.ScourConfig.MaximumGP;
+            if (ImGui.DragInt("Scour Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Scour.GpCost, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.ScourConfig.MaximumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+        
+        public static void DrawBrazenMaxGp()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MaximumGP;
+            if (ImGui.DragInt("Brazen Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
             }
         }
@@ -376,7 +416,27 @@ public partial class Interface
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP;
             if (ImGui.DragInt("Meticulous Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
             {
-                GatherBuddy.Config.AutoGatherConfig.LuckConfig.MinimumGP = (uint)tmp;
+                GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+        
+        public static void DrawScourMinGp()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.ScourConfig.MinimumGP;
+            if (ImGui.DragInt("Scour Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Scour.GpCost, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.ScourConfig.MinimumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+        
+        public static void DrawBrazenMinGp()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MinimumGP;
+            if (ImGui.DragInt("Brazen Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
             }
         }
@@ -911,6 +971,7 @@ public partial class Interface
                 AutoGatherUI.DrawMountSelector();
                 ConfigFunctions.DrawMountUpDistance();
                 ConfigFunctions.DrawMinimumGPGathering();
+                ConfigFunctions.DrawMinimumGPCollectibleRotation();
                 ConfigFunctions.DrawMinimumCollectibilityScore();
                 ConfigFunctions.DrawGatherIfLastIntegrity();
 
@@ -974,6 +1035,22 @@ public partial class Interface
                         ConfigFunctions.DrawMeticulousCheckbox();
                         ConfigFunctions.DrawMeticulousMinGp();
                         ConfigFunctions.DrawMeticulousMaxGp();
+                        ImGui.TreePop();
+                    }
+                    
+                    if (ImGui.TreeNodeEx("Scour"))
+                    {
+                        ConfigFunctions.DrawScourCheckbox();
+                        ConfigFunctions.DrawScourMinGp();
+                        ConfigFunctions.DrawScourMaxGp();
+                        ImGui.TreePop();
+                    }
+                    
+                    if (ImGui.TreeNodeEx("Brazen"))
+                    {
+                        ConfigFunctions.DrawBrazenCheckbox();
+                        ConfigFunctions.DrawBrazenMinGp();
+                        ConfigFunctions.DrawBrazenMaxGp();
                         ImGui.TreePop();
                     }
 


### PR DESCRIPTION
Reworked the Collectables actions conditions and logic to improve decision making and allow to choose when to do a full collect rotation.
- Removed specific conditions from the collectable actions.
- Added a class to handle the rotations. It's made with multiple rotations in mind so we can improve it with other rotations and a choice in the config later.
- Also fixed a bug in config where Meticulous min GP slider was linked to Luck min GP