### PR TITLE
Added consumables feature

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -37,6 +37,12 @@ namespace GatherBuddy.AutoGather
         public bool         GatherIfLastIntegrity                      { get; set; } = false;
         public uint         GatherIfLastIntegrityMinimumCollectibility { get; set; } = 600;
         public bool UseExperimentalNavigation { get; set; } = false;
+        public ConsumableConfig CordialConfig { get; set; } = new(false, 0, 700, 0);
+        public ConsumableConfig FoodConfig { get; set; } = new(false, 0, 0, 0);
+        public ConsumableConfig PotionConfig { get; set; } = new(false, 0, 0, 0);
+        public ConsumableConfig ManualConfig { get; set; } = new(false, 0, 0, 0);
+        public ConsumableConfig SquadronManualConfig { get; set; } = new(false, 0, 0, 0);
+        public ConsumableConfig SquadronPassConfig { get; set; } = new(false, 0, 0, 0);
 
         public class ActionConfig
         {
@@ -95,6 +101,22 @@ namespace GatherBuddy.AutoGather
             public bool        FilterNodeTypes    { get; set; }
             public NodeFilters NodeFilter         { get; set; }
             public uint        RequiredIntegrity   { get; set; }
+        }
+
+        public class ConsumableConfig
+        {
+            public ConsumableConfig(bool useConsumable, uint minGP, uint maximumGP, uint itemId)
+            {
+                UseConsumable = useConsumable;
+                MinimumGP = minGP;
+                MaximumGP = maximumGP;
+                ItemId = itemId;
+            }
+
+            public bool UseConsumable { get; set; }
+            public uint MinimumGP { get; set; }
+            public uint MaximumGP { get; set; }
+            public uint ItemId { get; set; }
         }
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Consumables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Consumables.cs
@@ -1,0 +1,255 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using ECommons.GameHelpers;
+using ECommons.Throttlers;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using Lumina.Excel.GeneratedSheets;
+
+namespace GatherBuddy.AutoGather
+{
+    public partial class AutoGather
+    {
+        public static readonly Item[] PossibleCordials = Dalamud.GameData.GetExcelSheet<Item>()?.Where(IsItemCordial).ToArray() ?? [];
+
+        public static readonly Item[] PossibleFoods = Dalamud.GameData.GetExcelSheet<Item>()?.Where(item => IsItemDoLFood(item)).ToArray() ?? [];
+
+        public static readonly Item[] PossiblePotions = Dalamud.GameData.GetExcelSheet<Item>()?.Where(item => IsItemDoLPotion(item)).ToArray() ?? [];
+
+        public static readonly Item[] PossibleManuals = Dalamud.GameData.GetExcelSheet<Item>()?.Where(item => IsItemDoLManual(item)).ToArray() ?? [];
+
+        private static readonly Dictionary<uint, uint> SquadronManualItemIdBuffId = new ()
+        {
+            { 14949u, 1081u },
+            { 14951u, 1083u },
+            { 14952u, 1084u },
+            { 14953u, 1085u },
+            { 41707u, 1084u }
+        };
+        public static readonly Item[] PossibleSquadronManuals = Dalamud.GameData.GetExcelSheet<Item>()?.Where(item => IsItemDoLSquadronManual(item)).ToArray() ?? [];
+
+        private static readonly Dictionary<uint, uint> SquadronPassItemIdBuffId = new ()
+        {
+            { 14954u, 1061u }
+        };
+        public static readonly Item[] PossibleSquadronPasses = Dalamud.GameData.GetExcelSheet<Item>()?.Where(item => IsItemDoLSquadronPass(item)).ToArray() ?? [];
+
+
+        public static unsafe int GetInventoryItemCount(uint itemRowId)
+        {
+            return InventoryManager.Instance()->GetInventoryItemCount(itemRowId < 100000 ? itemRowId : itemRowId - 100000, itemRowId >= 100000);
+        }
+
+        private static byte[] GetItemFoodProps(Item item)
+        {
+            // Item UI category: 44 medicine, 46 meal
+            if (item.ItemUICategory.Row is not 44 and not 46
+                || item.ItemAction.Value == null
+                // Buff: 48 well fed, 49 medicated
+                || item.ItemAction.Value.Data[0] is not 48 and not 49)
+                return [];
+            return Dalamud.GameData.GetExcelSheet<ItemFood>()?.GetRow(item.ItemAction.Value.Data[1])?.UnkData1.Select(v => v.BaseParam).ToArray() ?? [];
+        }
+
+        private static bool IsItemCordial(Item item)
+        {
+            return item.ItemAction?.Value?.Type == 1055;
+        }
+
+        private static bool IsItemDoLFood(Item item)
+        {
+            if (item.ItemUICategory.Row != 46)
+                return false;
+            // 10 GP, 71 gathering, 73 perception
+            return GetItemFoodProps(item).Any(p => p is 10 or 72 or 73);
+        }
+
+        private static bool IsItemDoLPotion(Item item)
+        {
+            if (item.ItemUICategory.Row != 44)
+                return false;
+            // 10 GP, 68 spiritbond, 69 durability, 72 gathering, 73 perception
+            return GetItemFoodProps(item).Any(p => p is 10 or 68 or 69 or 72 or 73);
+        }
+
+        private static bool IsItemDoLManual(Item item)
+        {
+            if (item.ItemUICategory.Row != 63)
+                return false;
+            return item.ItemAction?.Value?.Type == 816 && item.ItemAction?.Value?.Data[0] is 302 or 303 or 1752 or 5330;
+        }
+
+        private static bool IsItemDoLSquadronManual(Item item)
+        {
+            return SquadronManualItemIdBuffId.ContainsKey(item.RowId);
+        }
+
+        private static bool IsItemDoLSquadronPass(Item item)
+        {
+            return SquadronPassItemIdBuffId.ContainsKey(item.RowId);
+        }
+
+        public unsafe bool IsCordialOnCooldown
+        {
+            get
+            {
+                var cordialRecastGroup = ActionManager.Instance()->GetRecastGroupDetail(68);
+                return cordialRecastGroup->Total - cordialRecastGroup->Elapsed > 0;
+            }
+        }
+
+        public unsafe bool IsFoodBuffUp
+        {
+            get
+            {
+                var buff = Dalamud.ClientState?.LocalPlayer?.StatusList.FirstOrDefault(s => s.StatusId == 48);
+                if (buff == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    var configuredItem = PossibleFoods.FirstOrDefault(item => new[] { item.RowId, item.RowId + 100000 }.Contains(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId));
+                    if (GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId > 100000)
+                    {
+                        return buff.Param == configuredItem?.ItemAction.Value?.DataHQ[1] + 10000;
+                    }
+                    else
+                    {
+                        return buff.Param == configuredItem?.ItemAction.Value?.Data[1];
+                    }
+                }
+            }
+        }
+
+        public unsafe bool IsPotionBuffUp
+        {
+            get
+            {
+                var buff = Dalamud.ClientState?.LocalPlayer?.StatusList.FirstOrDefault(s => s.StatusId == 49);
+                if (buff == null)
+                {
+                    return false;
+                }
+                else
+                {
+                    var configuredItem = PossiblePotions.FirstOrDefault(item => new[] { item.RowId, item.RowId + 100000 }.Contains(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId));
+                    if (GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId > 100000)
+                    {
+                        return buff.Param == configuredItem?.ItemAction.Value?.DataHQ[1] + 10000;
+                    }
+                    else
+                    {
+                        return buff.Param == configuredItem?.ItemAction.Value?.Data[1];
+                    }
+                }
+            }
+        }
+
+        public unsafe bool IsManualBuffUp => Dalamud.ClientState?.LocalPlayer?.StatusList.Any(s => s.StatusId == 46) ?? false;
+
+        public unsafe bool IsSquadronManualBuffUp
+        {
+            get
+            {
+                if (SquadronManualItemIdBuffId.TryGetValue(GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId, out var requiredBuffId))
+                {
+                    return Dalamud.ClientState?.LocalPlayer?.StatusList.Any(s => s.StatusId == requiredBuffId) ?? false;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        public unsafe bool IsSquadronPassBuffUp
+        {
+            get
+            {
+                if (SquadronPassItemIdBuffId.TryGetValue(GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId, out var requiredBuffId))
+                {
+                    return Dalamud.ClientState?.LocalPlayer?.StatusList.Any(s => s.StatusId == requiredBuffId) ?? false;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+
+        private unsafe void UseItem(uint itemId)
+        {
+            // When calling ActionManager UseAction, HQ have ids 1,000,000 more than NQ, whereas Lumina Excel is 100,000
+            ActionManager.Instance()->UseAction(ActionType.Item, itemId > 100000 ? itemId + 900000 : itemId, extraParam: 65535);
+        }
+
+        // Cordial, food and potion have no cast time and can be used while mounted
+        private void DoUseConsumablesWithoutCastTime()
+        {
+            // Check if consumables need to be refreshed every 5 seconds
+            // Give sufficient time for buffs to activate otherwise items could be used multiple times and wasted
+            if (EzThrottler.Throttle("DoUseConsumablesWithoutCastTime", 5000))
+            {
+                if (GatherBuddy.Config.AutoGatherConfig.CordialConfig.UseConsumable
+                && GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId > 0
+                && !IsCordialOnCooldown
+                && Player.Object.CurrentGp >= GatherBuddy.Config.AutoGatherConfig.CordialConfig.MinimumGP
+                && Player.Object.CurrentGp <= GatherBuddy.Config.AutoGatherConfig.CordialConfig.MaximumGP
+                && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId) > 0
+                )
+                {
+                    TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId));
+                }
+
+                if (GatherBuddy.Config.AutoGatherConfig.FoodConfig.UseConsumable
+                    && GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId > 0
+                    && !IsFoodBuffUp
+                    && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId) > 0
+                    )
+                {
+                    TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId));
+                }
+
+                if (GatherBuddy.Config.AutoGatherConfig.PotionConfig.UseConsumable
+                    && GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId > 0
+                    && !IsPotionBuffUp
+                    && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId) > 0
+                    )
+                {
+                    TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId));
+                }
+            }
+        }
+
+        // Manuals have cast time and cannot be used while mounted
+        private void DoUseConsumablesWithCastTime()
+        {
+            if (GatherBuddy.Config.AutoGatherConfig.ManualConfig.UseConsumable
+                && GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId > 0
+                && !IsManualBuffUp
+                && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId) > 0
+                )
+            {
+                TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId));
+            }
+
+            if (GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.UseConsumable
+                && GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId > 0
+                && !IsSquadronManualBuffUp
+                && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId) > 0
+                )
+            {
+                TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId));
+            }
+
+            if (GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.UseConsumable
+                && GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId > 0
+                && !IsSquadronPassBuffUp
+                && GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId) > 0
+                )
+            {
+                TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId));
+            }
+        }
+    }
+}

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -107,6 +107,8 @@ namespace GatherBuddy.AutoGather
 
                 if (!Dalamud.Conditions[ConditionFlag.Mounted] && !Dalamud.Conditions[ConditionFlag.Jumping])
                 {
+                    // Use consumables with cast time just before gathering a node when player is surely not mounted
+                    DoUseConsumablesWithCastTime();
                     TaskManager.Enqueue(() => InteractWithNode(gameObject, targetItem));
                     return;
                 }

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -205,7 +205,23 @@ namespace GatherBuddy.AutoGather
                     VNavmesh_IPCSubscriber.Path_Stop();
                     GatherBuddy.Log.Verbose($"Navigating to {CurrentDestination}");
                     _lastNavigatedDestination = CurrentDestination.Value;
-                    var correctedDestination = shouldFly ? CurrentDestination.Value.CorrectForMesh() : CurrentDestination.Value;
+                    var loop                 = 1;
+                    var correctedDestination = shouldFly ? CurrentDestination.Value.CorrectForMesh(0.5f) : CurrentDestination.Value;
+                    while (Vector3.Distance(correctedDestination, CurrentDestination.Value) > 10 && loop < 8)
+                    {
+                        GatherBuddy.Log.Information("Distance last node and gatherpoint is too big : "
+                          + Vector3.Distance(correctedDestination, CurrentDestination.Value));
+                        correctedDestination = shouldFly ? CurrentDestination.Value.CorrectForMesh(loop * 0.5f) : CurrentDestination.Value;
+                        loop++;
+                    }
+
+                    if (Vector3.Distance(correctedDestination, CurrentDestination.Value) > 10)
+                    {
+                        GatherBuddy.Log.Warning($"Invalid destination: {correctedDestination}");
+                        ResetNavigation();
+                        return;
+                    }
+
                     if (!correctedDestination.SanityCheck())
                     {
                         GatherBuddy.Log.Warning($"Invalid destination: {correctedDestination}");
@@ -239,9 +255,10 @@ namespace GatherBuddy.AutoGather
         {
             if (TimedNodePosition == null)
                 return;
+
             var timedNode = potentialNodes
                 .Where(o => Vector3.Distance(new Vector3(TimedNodePosition.Value.X, o.Y, TimedNodePosition.Value.Y), o) < 10).OrderBy(o
-                    => Vector3.Distance(new Vector3(TimedNodePosition.Value.X, o.Z, TimedNodePosition.Value.Y), o)).FirstOrDefault(); 
+                    => Vector3.Distance(new Vector3(TimedNodePosition.Value.X, o.Z, TimedNodePosition.Value.Y), o)).FirstOrDefault();
             TaskManager.Enqueue(() => MoveToFarNode(timedNode));
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -3,7 +3,7 @@ using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using GatherBuddy.Plugin;
 using ImGuiNET;
-using Lumina.Excel.GeneratedSheets2;
+using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -184,6 +184,192 @@ namespace GatherBuddy.AutoGather
         public static string ToProperCase(this string input)
         {
             return System.Globalization.CultureInfo.CurrentCulture.TextInfo.ToTitleCase(input.ToLower());
+        }
+
+        public static unsafe void DrawCordialSelector()
+        {
+            // HQ items have IDs 100000 more than their NQ counterparts
+            var previewItem = AutoGather.PossibleCordials.FirstOrDefault(item => new[] { item.RowId, item.RowId + 100000 }.Contains(GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId));
+            // PluginLog.Information(JsonConvert.SerializeObject(previewItem.ItemAction));
+            if (ImGui.BeginCombo("Select Cordial", previewItem is null
+                ? ""
+                : $"{(GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId > 100000 ? " " : "")}{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossibleCordials.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                    if (item.CanBeHq)
+                    {
+                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == item.RowId + 100000))
+                        {
+                            GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = item.RowId + 100000;
+                            GatherBuddy.Config.Save();
+                        }
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+        }
+
+        public static unsafe void DrawFoodSelector()
+        {
+            // HQ items have IDs 100000 more than their NQ counterparts
+            var previewItem = AutoGather.PossibleFoods.FirstOrDefault(item => new[] { item.RowId, item.RowId + 100000 }.Contains(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId));
+            // PluginLog.Information(JsonConvert.SerializeObject(previewItem.ItemAction));
+            if (ImGui.BeginCombo("Select Food", previewItem is null
+                ? ""
+                : $"{(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId > 100000 ? " " : "")}{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossibleFoods.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                    if (item.CanBeHq)
+                    {
+                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == item.RowId + 100000))
+                        {
+                            GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = item.RowId + 100000;
+                            GatherBuddy.Config.Save();
+                        }
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+        }
+
+        public static unsafe void DrawPotionSelector()
+        {
+            // HQ items have IDs 100000 more than their NQ counterparts
+            var previewItem = AutoGather.PossiblePotions.FirstOrDefault(item => new[] { item.RowId, item.RowId + 100000 }.Contains(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId));
+            // PluginLog.Information(JsonConvert.SerializeObject(previewItem.ItemAction));
+            if (ImGui.BeginCombo("Select Potion", previewItem is null
+                ? ""
+                : $"{(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId > 100000 ? " " : "")}{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossiblePotions.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                    if (item.CanBeHq)
+                    {
+                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == item.RowId + 100000))
+                        {
+                            GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = item.RowId + 100000;
+                            GatherBuddy.Config.Save();
+                        }
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+        }
+
+        public static unsafe void DrawManualSelector()
+        {
+            var previewItem = AutoGather.PossibleManuals.FirstOrDefault(item => item.RowId == GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId);
+            if (ImGui.BeginCombo("Select Manual", previewItem is null
+                ? ""
+                : $"{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossibleManuals.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+        }
+
+        public static unsafe void DrawSquadronManualSelector()
+        {
+            var previewItem = AutoGather.PossibleSquadronManuals.FirstOrDefault(item => item.RowId == GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId);
+            if (ImGui.BeginCombo("Select Squadron Manual", previewItem is null
+                ? ""
+                : $"{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossibleSquadronManuals.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
+        }
+
+        public static unsafe void DrawSquadronPassSelector()
+        {
+            var previewItem = AutoGather.PossibleSquadronPasses.FirstOrDefault(item => item.RowId == GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId);
+            if (ImGui.BeginCombo("Select Squadron Pass", previewItem is null
+                ? ""
+                : $"{previewItem.Name} ({AutoGather.GetInventoryItemCount(GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId)})"))
+            {
+                if (ImGui.Selectable("", GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId == 0))
+                {
+                    GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId = 0;
+                    GatherBuddy.Config.Save();
+                }
+
+                foreach (var item in AutoGather.PossibleSquadronPasses.OrderBy(item => item.Name.ToString()))
+                {
+                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId == item.RowId))
+                    {
+                        GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.Save();
+                    }
+                }
+
+                ImGui.EndCombo();
+            }
         }
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -88,7 +88,7 @@ namespace GatherBuddy.AutoGather
                 var marker             = map->FlagMapMarker;
                 var mapPosition        = new Vector2(marker.XFloat, marker.YFloat);
                 var uncorrectedVector3 = new Vector3(mapPosition.X, 1024, mapPosition.Y);
-                var correctedVector3   = uncorrectedVector3.CorrectForMesh();
+                var correctedVector3   = uncorrectedVector3.CorrectForMesh(0.5f);
                 if (uncorrectedVector3 == correctedVector3)
                     return null;
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -136,8 +136,8 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-
-
+            DoUseConsumablesWithoutCastTime();
+            
             if (IsPathGenerating)
             {
                 AutoStatus = "Generating path...";

--- a/GatherBuddy/CustomInfo/FuzzyVector3.cs
+++ b/GatherBuddy/CustomInfo/FuzzyVector3.cs
@@ -15,30 +15,33 @@ namespace GatherBuddy.CustomInfo
         {
             var random = new Random();
             var vector = new Vector3(
-                                              value.X + (float)random.NextDouble() * fuzziness,
-                                                                                           value.Y + (float)random.NextDouble() * fuzziness,
-                                                                                                                                                       value.Z + (float)random.NextDouble() * fuzziness
-                                                                                                                                                                                                                              );
+                value.X + (float)random.NextDouble() * fuzziness,
+                value.Y + (float)random.NextDouble() * fuzziness,
+                value.Z + (float)random.NextDouble() * fuzziness
+            );
             GatherBuddy.Log.Verbose($"Fuzzed vector {value} to {vector}");
             return vector;
         }
-        public static Vector3 CorrectForMesh(this Vector3 vector)
+
+        public static Vector3 CorrectForMesh(this Vector3 vector, float distance)
         {
             try
             {
                 try
                 {
-                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(vector, 0.5f, 0.5f);
+                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(vector, distance, distance);
                     if (!nearestPoint.SanityCheck())
                         return vector;
+
                     GatherBuddy.Log.Verbose($"Corrected vector {vector} to floor point {nearestPoint}");
                     return nearestPoint;
                 }
                 catch (Exception)
                 {
-                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(vector, 0.5f, 0.5f);
+                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(vector, distance, distance);
                     if (!nearestPoint.SanityCheck())
                         return vector;
+
                     GatherBuddy.Log.Verbose($"Corrected vector {vector} to {nearestPoint}");
                     return nearestPoint;
                 }
@@ -61,6 +64,7 @@ namespace GatherBuddy.CustomInfo
 
             return true;
         }
+
         public static float DistanceToPlayer(this Vector3 vector)
         {
             var distance = Vector3.Distance(vector, Player.Object.Position);

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -471,6 +471,68 @@ public partial class Interface
             }
         }
 
+        public static void DrawCordialCheckbox()
+            => DrawCheckbox(
+                "Use Cordial",
+                "Use Cordial if item is available, not on cooldown and GP is within the specified range.",
+                GatherBuddy.Config.AutoGatherConfig.CordialConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.CordialConfig.UseConsumable = b);
+
+        public static void DrawCordialMinGP()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.CordialConfig.MinimumGP;
+            if (ImGui.DragInt("Cordial Min GP", ref tmp, 1, 0, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.CordialConfig.MinimumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+
+        public static void DrawCordialMaxGP()
+        {
+            int tmp = (int)GatherBuddy.Config.AutoGatherConfig.CordialConfig.MaximumGP;
+            if (ImGui.DragInt("Cordial Max GP", ref tmp, 1, 1000, 30000))
+            {
+                GatherBuddy.Config.AutoGatherConfig.CordialConfig.MaximumGP = (uint)tmp;
+                GatherBuddy.Config.Save();
+            }
+        }
+
+        public static void DrawFoodCheckbox()
+            => DrawCheckbox(
+                "Use Food",
+                "Use food if item is available and buff is not up.",
+                GatherBuddy.Config.AutoGatherConfig.FoodConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.FoodConfig.UseConsumable = b);
+
+        public static void DrawPotionCheckbox()
+            => DrawCheckbox(
+                "Use Potion",
+                "Use potion if item is available and buff is not up.",
+                GatherBuddy.Config.AutoGatherConfig.PotionConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.PotionConfig.UseConsumable = b);
+
+        public static void DrawManualCheckbox()
+            => DrawCheckbox(
+                "Use Manual",
+                "Use manual if item is available and buff is not up.",
+                GatherBuddy.Config.AutoGatherConfig.ManualConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.ManualConfig.UseConsumable = b);
+
+        public static void DrawSquadronManualCheckbox()
+            => DrawCheckbox(
+                "Use Squadron Manual",
+                "Use squadron manual if item is available and buff is not up.",
+                GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.UseConsumable = b);
+
+        public static void DrawSquadronPassCheckbox()
+            => DrawCheckbox(
+                "Use Squadron Pass",
+                "Use squadron pass if item is available and buff is not up.",
+                GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.UseConsumable,
+                b => GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.UseConsumable = b);
+
         public static void DrawAntiStuckCooldown()
         {
             var tmp = GatherBuddy.Config.AutoGatherConfig.NavResetCooldown;
@@ -1083,7 +1145,55 @@ public partial class Interface
                 ImGui.TreePop();
             }
 
-            if (ImGui.TreeNodeEx("Advanced"))
+            if (ImGui.TreeNodeEx("Consumables"))
+            {
+                if (ImGui.TreeNodeEx("Cordial"))
+                {
+                    ConfigFunctions.DrawCordialCheckbox();
+                    ConfigFunctions.DrawCordialMinGP();
+                    ConfigFunctions.DrawCordialMaxGP();
+                    AutoGatherUI.DrawCordialSelector();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Food"))
+                {
+                    ConfigFunctions.DrawFoodCheckbox();
+                    AutoGatherUI.DrawFoodSelector();
+                    ImGui.TreePop();
+                }
+                
+                if (ImGui.TreeNodeEx("Potion"))
+                {
+                    ConfigFunctions.DrawPotionCheckbox();
+                    AutoGatherUI.DrawPotionSelector();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Manual"))
+                {
+                    ConfigFunctions.DrawManualCheckbox();
+                    AutoGatherUI.DrawManualSelector();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Squadron Manual"))
+                {
+                    ConfigFunctions.DrawSquadronManualCheckbox();
+                    AutoGatherUI.DrawSquadronManualSelector();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Squadron Pass"))
+                {
+                    ConfigFunctions.DrawSquadronPassCheckbox();
+                    AutoGatherUI.DrawSquadronPassSelector();
+                    ImGui.TreePop();
+                }
+                ImGui.TreePop();
+            }
+
+                if (ImGui.TreeNodeEx("Advanced"))
             {
                 ConfigFunctions.DrawAutoGatherBox();
                 ConfigFunctions.DrawUseFlagBox();

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -600,6 +600,12 @@ public partial class Interface
         ImGui.Text(($"HasSeenFlag: {GatherBuddy.AutoGather.HasSeenFlag}"));
         ImGui.Text($"LastIntegrity: {GatherBuddy.AutoGather.LastIntegrity}");
         ImGui.Text($"LastCollectScore: {GatherBuddy.AutoGather.LastCollectability}");
+        ImGui.Text($"IsCordialOnCooldown: {GatherBuddy.AutoGather.IsCordialOnCooldown}");
+        ImGui.Text($"IsFoodBuffUp: {GatherBuddy.AutoGather.IsFoodBuffUp}");
+        ImGui.Text($"IsPotionBuffUp: {GatherBuddy.AutoGather.IsPotionBuffUp}");
+        ImGui.Text($"IsManualBuffUp: {GatherBuddy.AutoGather.IsManualBuffUp}");
+        ImGui.Text($"IsSquadronManualBuffUp: {GatherBuddy.AutoGather.IsSquadronManualBuffUp}");
+        ImGui.Text($"IsSquadronPassBuffUp: {GatherBuddy.AutoGather.IsSquadronPassBuffUp}");
 
         if (ImGui.CollapsingHeader("Timed Node Memory"))
         {


### PR DESCRIPTION
The consumables feature should be functional based on my own testing, though the code organization may not align with your needs. You may refactor it after testing that the features are indeed working correctly.

1. `AutoGather.Config.cs`: Added ConsumableConfig class to hold consumables configuration data.
2. `AutoGather.Consumables.cs`: Added new file to hold most consumables logic.
3. `AutoGather.Movement.cs`: Some consumables have cast time and can only be used while unmounted. I can't find a good spot to insert into `AutoGather.cs` where the player is guaranteed to be unmounted, and I didn't want to trigger unmounting in case it breaks navigation. Hence, I inserted one line into `AutoGather.Movement.cs` just before the player starts gathering a node. Please adjust this logic if needed.
4. `AutoGather.Ui.cs`: Added UI for consumables. Changed from using `Lumina.Excel.GeneratedSheets2` to `Lumina.Excel.GeneratedSheets` to access item properties related to consumables. Does not affect mount logic. (Suggest to not query the Excel data within `DrawMountSelector` function because this function runs very frequently whenever the UI is visible. Consider initializing a readonly variable holding all mount data when the plugin loads, then filter unlocked mounts within the UI draw function.)
5. `AutoGather.cs`: Inserted using consumable (without cast time) to be below the player being in gathering state so that the player is not blocked by trying and failing to use consumables while gathering.
6. `Interface.ConfigTab.cs`: Added UI for consumables.
7. `Interface.DebugTab.cs`: Added some variables to debug if consumable cooldowns and buffs are tracked correctly.