### PR TITLE
Improved gather action queuing and waits

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -148,7 +148,7 @@ namespace GatherBuddy.AutoGather
             var amInstance = ActionManager.Instance();
             if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
             {
-                Communicator.Print("Action used: " + act.Name);
+                //Communicator.Print("Action used: " + act.Name);
                 amInstance->UseAction(ActionType.Action, act.ActionID);
             }
         }
@@ -159,7 +159,7 @@ namespace GatherBuddy.AutoGather
             if (additionalDelay > 0)
                 TaskManager.DelayNextImmediate(additionalDelay);
             TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
-            Communicator.Print("Ready for next action.");
+            //Communicator.Print("Ready for next action.");
         }
 
         private unsafe void DoCollectibles()
@@ -199,7 +199,7 @@ namespace GatherBuddy.AutoGather
                 }
                 EnqueueGatherAction(() =>
                 {
-                    UseAction(CurrentRotation.GetNextAction(MasterpieceAddon));
+                    UseAction(collectibleAction);
                 }, 250);
             }
         }

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -104,8 +104,6 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void DoActionTasks(Gatherable desiredItem)
         {
-            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
-
             if (GatheringAddon == null && MasterpieceAddon == null)
                 return;
 
@@ -143,14 +141,11 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void UseAction(Actions.BaseAction act)
         {
-            if (EzThrottler.Throttle($"Action: {act.Name}", 10))
+            var amInstance = ActionManager.Instance();
+            if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
             {
-                var amInstance = ActionManager.Instance();
-                if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
-                {
-                    amInstance->UseAction(ActionType.Action, act.ActionID);
-                    TaskManager.DelayNextImmediate(2500);
-                }
+                amInstance->UseAction(ActionType.Action, act.ActionID);
+                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -145,7 +145,8 @@ namespace GatherBuddy.AutoGather
             if (amInstance->GetActionStatus(ActionType.Action, act.ActionID) == 0)
             {
                 amInstance->UseAction(ActionType.Action, act.ActionID);
-                TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Gathering42]);
+                TaskManager.EnqueueImmediate(() => !Svc.Condition[ConditionFlag.Gathering42]);
+                TaskManager.Enqueue(() => Communicator.Print("Ready for next action."));
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -21,7 +21,7 @@ namespace GatherBuddy.AutoGather
             public Actions.BaseAction? GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
             {
                 var action = shouldUseFullRotation ? FullRotation(MasterpieceAddon) : FillerRotation(MasterpieceAddon);
-                Communicator.Print("Resolving action: " + action.Name);
+                //Communicator.Print("Resolving action: " + action.Name);
                 return action;
             }
             

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -1,6 +1,7 @@
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using System.Linq;
+using GatherBuddy.Plugin;
 
 namespace GatherBuddy.AutoGather
 {
@@ -15,9 +16,14 @@ namespace GatherBuddy.AutoGather
             }
             
             private bool shouldUseFullRotation = false;
-            
+
             public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
-                => shouldUseFullRotation ? FullRotation(MasterpieceAddon) : FillerRotation(MasterpieceAddon);
+            {
+                var action = shouldUseFullRotation ? FullRotation(MasterpieceAddon) : FillerRotation(MasterpieceAddon);
+                Communicator.Print("Resolving action: " + action.Name);
+                return action;
+            }
+            
 
             private Actions.BaseAction FullRotation(AddonGatheringMasterpiece* MasterpieceAddon)
             {

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -64,7 +64,7 @@ namespace GatherBuddy.AutoGather
             var eventData = EventData.ForNormalTarget(target, &GatheringAddon->AtkUnitBase);
             var inputData = InputData.Empty();
 
-            Communicator.Print("Queuing click.");
+            //Communicator.Print("Queuing click.");
             EnqueueGatherAction(() => eventDelegate.Invoke(&GatheringAddon->AtkUnitBase.AtkEventListener, EventType.CHANGE, (uint)itemIndex, eventData.Data,
                 inputData.Data));
         }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -14,6 +14,7 @@ using System.Threading.Tasks;
 using Dalamud.Game;
 using ECommons;
 using ECommons.Automation.UIInput;
+using GatherBuddy.Plugin;
 using OtterGui;
 using NodeType = GatherBuddy.Enums.NodeType;
 
@@ -63,8 +64,9 @@ namespace GatherBuddy.AutoGather
             var eventData = EventData.ForNormalTarget(target, &GatheringAddon->AtkUnitBase);
             var inputData = InputData.Empty();
 
-            eventDelegate.Invoke(&GatheringAddon->AtkUnitBase.AtkEventListener, EventType.CHANGE, (uint)itemIndex, eventData.Data,
-                inputData.Data);
+            Communicator.Print("Queuing click.");
+            EnqueueGatherAction(() => eventDelegate.Invoke(&GatheringAddon->AtkUnitBase.AtkEventListener, EventType.CHANGE, (uint)itemIndex, eventData.Data,
+                inputData.Data));
         }
 
         private int GetIndexOfItemToClick(uint[] ids, IGatherable item)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -132,7 +132,7 @@ namespace GatherBuddy.AutoGather
             {
                 AutoStatus = "Gathering...";
                 TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
-                TaskManager.Enqueue(() => DoActionTasks(targetItem));
+                DoActionTasks(targetItem);
                 return;
             }
 


### PR DESCRIPTION
- I reworked the queuing / throttling during gathering to make sure we never queue an action while already doing a gather action.
- Delay is now minimal (250ms instead of 2000ms previously), and only used during collectable actions. The issue there was scrutiny making the player go in and out of Gathering42 condition very quickly, waiting a few frames before checking the condition fixed the issue. 
- Probably needs a bit of testing but I've been runing it all afternoon yesterday with the Prints I commented in the code, and didn't get a single action being used out of place / during another action.