### PR TITLE
Minor collectables improvements

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -81,11 +81,23 @@ namespace GatherBuddy.AutoGather
             {
                 int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
                 int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
+                int maxIntegrity     = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(129)->NodeText.ToString());
                 int scourColl        = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString().Substring(2));
                 int meticulousColl   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString().Substring(2));
 
-                if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore && ShouldCollect())
-                    return Actions.Collect;
+                if (currentIntegrity < maxIntegrity
+                 && ShouldUseWise(currentIntegrity, maxIntegrity))
+                    return Actions.Wise;
+
+                if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore)
+                {
+                    if (currentIntegrity <= maxIntegrity && GatherBuddy.Config.AutoGatherConfig.AlwaysUseSolidAgeCollectables
+                     && ShouldSolidAgeCollectables(currentIntegrity, maxIntegrity))
+                        return Actions.SolidAge;
+
+                    if (ShouldCollect())
+                        return Actions.Collect;
+                }
 
                 if (currentIntegrity == 1
                  && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -20,14 +20,6 @@ namespace GatherBuddy.AutoGather
 
             public Actions.BaseAction? GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
             {
-                var action = shouldUseFullRotation ? FullRotation(MasterpieceAddon) : FillerRotation(MasterpieceAddon);
-                //Communicator.Print("Resolving action: " + action.Name);
-                return action;
-            }
-            
-
-            private Actions.BaseAction? FullRotation(AddonGatheringMasterpiece* MasterpieceAddon)
-            {
                 int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
                 int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
                 int maxIntegrity     = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(129)->NodeText.ToString());
@@ -41,7 +33,7 @@ namespace GatherBuddy.AutoGather
 
                 if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore)
                 {
-                    if (currentIntegrity <= maxIntegrity
+                    if (currentIntegrity <= maxIntegrity && (shouldUseFullRotation || GatherBuddy.Config.AutoGatherConfig.AlwaysUseSolidAgeCollectables)
                      && ShouldSolidAgeCollectables(currentIntegrity, maxIntegrity))
                         return Actions.SolidAge;
 
@@ -55,7 +47,7 @@ namespace GatherBuddy.AutoGather
                  && ShouldCollect())
                     return Actions.Collect;
 
-                if (NeedScrutiny(collectability, scourColl, meticulousColl, brazenColl) && ShouldUseScrutiny())
+                if (shouldUseFullRotation && NeedScrutiny(collectability, scourColl, meticulousColl, brazenColl) && ShouldUseScrutiny())
                     return Actions.Scrutiny;
 
                 if (meticulousColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
@@ -68,51 +60,6 @@ namespace GatherBuddy.AutoGather
                 if (scourColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
                  && ShouldUseScour())
                     return Actions.Scour;
-
-                if (ShouldUseMeticulous())
-                    return Actions.Meticulous;
-
-                return null;
-            }
-
-            private Actions.BaseAction? FillerRotation(AddonGatheringMasterpiece* MasterpieceAddon)
-            {
-                int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
-                int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
-                int maxIntegrity     = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(129)->NodeText.ToString());
-                int scourColl        = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString().Substring(2));
-                int meticulousColl   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString().Substring(2));
-
-                if (currentIntegrity < maxIntegrity
-                 && ShouldUseWise(currentIntegrity, maxIntegrity))
-                    return Actions.Wise;
-
-                if (collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore)
-                {
-                    if (currentIntegrity <= maxIntegrity && GatherBuddy.Config.AutoGatherConfig.AlwaysUseSolidAgeCollectables
-                     && ShouldSolidAgeCollectables(currentIntegrity, maxIntegrity))
-                        return Actions.SolidAge;
-
-                    if (ShouldCollect())
-                        return Actions.Collect;
-                }
-
-                if (currentIntegrity == 1
-                 && GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrity
-                 && collectability >= GatherBuddy.Config.AutoGatherConfig.GatherIfLastIntegrityMinimumCollectibility
-                 && ShouldCollect())
-                    return Actions.Collect;
-
-                if (meticulousColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-                 && ShouldUseMeticulous())
-                    return Actions.Meticulous;
-
-                if (scourColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-                 && ShouldUseScour())
-                    return Actions.Scour;
-
-                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911) && ShouldUseBrazen())
-                    return Actions.Brazen;
 
                 if (ShouldUseMeticulous())
                     return Actions.Meticulous;

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -62,9 +62,7 @@ namespace GatherBuddy.AutoGather
                  && ShouldUseMeticulous())
                     return Actions.Meticulous;
 
-                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911)
-                 && brazenColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore
-                 && ShouldUseBrazen())
+                if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s => s.StatusId == 3911) && ShouldUseBrazen())
                     return Actions.Brazen;
 
                 if (scourColl + collectability >= GatherBuddy.Config.AutoGatherConfig.MinimumCollectibilityScore

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -45,6 +45,7 @@ namespace GatherBuddy.AutoGather
         public bool DoGathering { get; set; } = true;
         public uint MinimumGPForGathering { get; set; } = 0;
         public uint MinimumGPForCollectableRotation { get; set; } = 700;
+        public bool AlwaysUseSolidAgeCollectables { get; set; } = false;
         public uint MinimumGPForCollectable { get; set; } = 0;
         public float NavResetCooldown { get; set; } = 3.0f;
         public float NavResetThreshold { get; set; } = 2.0f;

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -105,6 +105,9 @@ public partial class Interface
                 GatherBuddy.Config.Save();
             }
         }
+        public static void DrawAlwaysUseSolidAgeCollectables()
+            => DrawCheckbox("Ignore the above setting for Solid Reason / Ageless Words", "Use Solid Reason / Ageless Words regardless of starting GP if target collectability score is reached",
+                GatherBuddy.Config.AutoGatherConfig.AlwaysUseSolidAgeCollectables, b => GatherBuddy.Config.AutoGatherConfig.AlwaysUseSolidAgeCollectables = b);
 
         public static void DrawMinimumGPCollectable()
         {
@@ -1195,6 +1198,7 @@ public partial class Interface
             {
                 ConfigFunctions.DrawMinimumGPCollectable();
                 ConfigFunctions.DrawMinimumGPCollectibleRotation();
+                ConfigFunctions.DrawAlwaysUseSolidAgeCollectables();
                 ConfigFunctions.DrawMinimumCollectibilityScore();
                 ConfigFunctions.DrawGatherIfLastIntegrity();
 


### PR DESCRIPTION
1) Option to use Solid Reason / Ageless Words when you are lucky enough to hit the target collectability rating with the filler rotation.
2) Always use Brazen if Collector's High Standard is up (this was true only for filler rotation).
3) Merge FillerRotation() and FullRotation() into one.