### PR TITLE
QoL improvements and fixes for some corner cases

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -20,7 +20,7 @@ namespace GatherBuddy.AutoGather
                 return false;
             if (Player.Object.CurrentGp < Actions.Luck.GpCost)
                 return false;
-            if (!gatherable.GatheringData.IsHidden)
+            if (!gatherable.GatheringData.IsHidden && gatherable.ItemData.FilterGroup != 18 /*treasure maps*/)
                 return false;
 
             if (ids.Length > 0 && ids.Contains(gatherable.ItemId))

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -16,6 +16,8 @@ namespace GatherBuddy.AutoGather
         {
             if (gatherable == null)
                 return false;
+            if (HiddenRevealed)
+                return false;
             if (Player.Level < Actions.Luck.MinLevel)
                 return false;
             if (Player.Object.CurrentGp < Actions.Luck.GpCost)
@@ -227,7 +229,10 @@ namespace GatherBuddy.AutoGather
                         else if (ShouldUseTwelvesBounty(desiredItem as Gatherable))
                             EnqueueGatherAction(() => UseAction(Actions.TwelvesBounty));
                         else if (ShouldUseLuck(ids, desiredItem as Gatherable))
+                        {
+                            HiddenRevealed = true;
                             EnqueueGatherAction(() => UseAction(Actions.Luck));
+                        }
                         else if (ShouldUseKingII(desiredItem as Gatherable))
                             EnqueueGatherAction(() => UseAction(Actions.Yield2));
                         else if (ShouldUseKingI(desiredItem as Gatherable))

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -160,7 +160,7 @@ namespace GatherBuddy.AutoGather
         }
 
 
-        private unsafe void DoActionTasks(Gatherable desiredItem)
+        private unsafe void DoActionTasks(Gatherable? desiredItem)
         {
             if (GatheringAddon == null && MasterpieceAddon == null
              || Svc.Condition[ConditionFlag.Gathering42])
@@ -183,7 +183,7 @@ namespace GatherBuddy.AutoGather
                 CurrentRotation = null;
         }
 
-        private unsafe void DoGatherWindowActions(Gatherable desiredItem)
+        private unsafe void DoGatherWindowActions(Gatherable? desiredItem)
         {
             if (GatheringAddon != null)
             {
@@ -214,7 +214,7 @@ namespace GatherBuddy.AutoGather
                                 return;
                             }
                         }
-                        if (MaybeGatherSometingElse(ref desiredItem, ids))
+                        if (MaybeGatherSometingElse(ref desiredItem!, ids))
                         {
 
                             if (ShouldUseWise(currentIntegrity, maxIntegrity))

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -243,7 +243,7 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        private unsafe int GetCurrentYield(int itemPosition)
+        private unsafe int GetCurrentYield(int itemPosition, bool accountForGivingLand = true)
         {
             var itemCheckbox = GatheringAddon->GatheredItemComponentCheckbox[itemPosition].Value;
 
@@ -259,11 +259,11 @@ namespace GatherBuddy.AutoGather
                 {
                     var match = Regex.Match(yield, @"^(\d)+\+\?$");
                     if (match.Success)
-                        result = int.Parse(match.Groups[1].Value) + GivingLandYeild;
+                        result = int.Parse(match.Groups[1].Value) + (accountForGivingLand ? GivingLandYeild : 0);
                 }
             }
 
-            if (Dalamud.ClientState.LocalPlayer.StatusList.Any(s
+            if (Dalamud.ClientState.LocalPlayer!.StatusList.Any(s
                     => BountifulYieldStatuses
                         .Contains(s.StatusId))) // Has BYII. This is a quality check as Solid will take priority over BYII anyway.
                 result -= 3;                    //I consider the maximum proc, I don't know if we have a way to make a better check.

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -211,9 +211,10 @@ namespace GatherBuddy.AutoGather
                             {
                                 HiddenRevealed = true;
                                 EnqueueGatherAction(() => UseAction(Actions.Luck));
+                                return;
                             }
                         }
-                        else if (MaybeGatherSometingElse(ref desiredItem, ids))
+                        if (MaybeGatherSometingElse(ref desiredItem, ids))
                         {
 
                             if (ShouldUseWise(currentIntegrity, maxIntegrity))

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -133,7 +133,7 @@ namespace GatherBuddy.AutoGather
             return true;
         }
 
-        private unsafe bool ShouldUseTwelvesBounty(Gatherable item, uint[] ids)
+        private unsafe bool ShouldUseTwelvesBounty(Gatherable? item, uint[] ids)
         {
             if (item == null)
                 return false;
@@ -196,15 +196,21 @@ namespace GatherBuddy.AutoGather
                     {
                         var ids = GetGatherableIds();
 
-                        if (ids.Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault).Any(item => item != null && (item.GatheringData.IsHidden || IsTreasureMap(item))))
+                        if (!HiddenRevealed && currentIntegrity == maxIntegrity 
+                            && ids.Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault).Any(item => item != null && (item.GatheringData.IsHidden || IsTreasureMap(item))))
                         {
                             //Don't use Luck if hidden item is already revealed
                             HiddenRevealed = true;
                         }
-                        if (ShouldUseLuck(desiredItem))
+
+                        if (!HasGivingLandBuff && ShouldUseLuck(desiredItem))
                         {
-                            HiddenRevealed = true;
-                            EnqueueGatherAction(() => UseAction(Actions.Luck));
+                            var anyCrystall = ids.Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault).Where(i => i != null && IsCrystal(i)).OrderBy(i => GetInventoryItemCount(i!.ItemId));
+                            if (!GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown || !ShouldUseTwelvesBounty(anyCrystall.FirstOrDefault(), ids))
+                            {
+                                HiddenRevealed = true;
+                                EnqueueGatherAction(() => UseAction(Actions.Luck));
+                            }
                         }
                         else if (MaybeGatherSometingElse(ref desiredItem, ids))
                         {

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -54,7 +54,6 @@ namespace GatherBuddy.AutoGather
         public uint MinimumCollectibilityScore { get; set; } = 1000;
         public bool GatherIfLastIntegrity { get; set; } = false;
         public uint GatherIfLastIntegrityMinimumCollectibility { get; set; } = 600;
-        public bool UseExperimentalNavigation { get; set; } = false;
         public bool UseExperimentalUnstuck { get; set; } = false;
         public ConsumableConfig CordialConfig { get; set; } = new(false, 0, 700, 0);
         public ConsumableConfig FoodConfig { get; set; } = new(false, 0, 0, 0);

--- a/GatherBuddy/AutoGather/AutoGather.Consumables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Consumables.cs
@@ -225,7 +225,7 @@ namespace GatherBuddy.AutoGather
         }
 
         // Manuals have cast time and cannot be used while mounted
-        private void DoUseConsumablesWithCastTime()
+        private bool DoUseConsumablesWithCastTime()
         {
             if (GatherBuddy.Config.AutoGatherConfig.ManualConfig.UseConsumable
                 && GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId > 0
@@ -234,7 +234,7 @@ namespace GatherBuddy.AutoGather
                 )
             {
                 TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId));
-                return;
+                return true;
             }
 
             if (GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.UseConsumable
@@ -244,7 +244,7 @@ namespace GatherBuddy.AutoGather
                 )
             {
                 TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId));
-                return;
+                return true;
             }
 
             if (GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.UseConsumable
@@ -254,8 +254,9 @@ namespace GatherBuddy.AutoGather
                 )
             {
                 TaskManager.Enqueue(() => UseItem(GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId));
-                return;
+                return true;
             }
+            return false;
         }
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -152,7 +152,7 @@ namespace GatherBuddy.AutoGather
             if (IsTreasureMap(item) && InventoryCount(item) != 0)
                 return false;
             //If it's a crystal, we can't have more than 9999
-            if (IsCrystal(item) && InventoryCount(item) > 9999 - (HasGivingLandBuff ? GivingLandYeild : GetCurrentYield(index)))
+            if (IsCrystal(item) && InventoryCount(item) > 9999 - GetCurrentYield(index))
                 return false;
             return true;
         }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -89,7 +89,7 @@ namespace GatherBuddy.AutoGather
                 .ToList();
 
             //Gather crystals when using The Giving Land
-            if (crystals.Any() && (HasGivingLandBuff || GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown && ShouldUseGivingLand(crystals.First())))
+            if (crystals.Any() && (HasGivingLandBuff || GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown && ShouldUseGivingLand(crystals.First(), ids)))
             {
                 desiredItem = crystals.First();
                 return true;

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -95,7 +95,7 @@ namespace GatherBuddy.AutoGather
                 //Prioritize crystals with a lower amount in the inventory
                 .OrderBy(InventoryCount)
                 //Prioritize crystals in the gathering list
-                .OrderBy(item => ItemsToGather.Concat(TimedItemsToGather).Any(toGather => toGather.ItemId == item.ItemId) ? 0 : 1)
+                .OrderBy(item => ItemsToGather.Any(toGather => toGather.ItemId == item.ItemId) ? 0 : 1)
                 .ToArray();
 
             //Gather crystals when using The Giving Land
@@ -107,7 +107,7 @@ namespace GatherBuddy.AutoGather
 
             var shouldGather = aviable
                 //Item is in gathering list
-                .Where(item => ItemsToGather.Concat(TimedItemsToGather).Any(g => g.ItemId == item.ItemId))
+                .Where(item => ItemsToGather.Any(g => g.ItemId == item.ItemId))
                 //And we need more of it
                 .Where(item => InventoryCount(item) < QuantityTotal(item));
 

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -58,6 +58,8 @@ namespace GatherBuddy.AutoGather
             //Communicator.Print("Queuing click.");
             EnqueueGatherAction(() => eventDelegate.Invoke(&GatheringAddon->AtkUnitBase.AtkEventListener, EventType.CHANGE, (uint)itemIndex, eventData.Data,
                 inputData.Data));
+            if (IsTreasureMap(item))
+                EnqueueGatherAction(RefreshNextTresureMapAllowance);
         }
 
         private unsafe uint[] GetGatherableIds()

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -72,7 +72,7 @@ namespace GatherBuddy.AutoGather
         /// Checks if desired item could or should be gathered and may change it to something more suitable
         /// </summary>
         /// <returns>True if the selected item is in the gathering list; false if we gather some unneeded junk</returns>
-        private bool MaybeGatherSometingElse(ref Gatherable desiredItem, uint[] ids)
+        private bool MaybeGatherSometingElse(ref Gatherable? desiredItem, uint[] ids)
         {
             var aviable = ids
                 .Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault)
@@ -85,7 +85,7 @@ namespace GatherBuddy.AutoGather
                 //Prioritize crystals with a lower amount in the inventory
                 .OrderBy(InventoryCount)
                 //Prioritize crystals in the gathering list
-                .OrderBy(item => ItemsToGather.Any(toGather => toGather.ItemId == item.ItemId) ? 0 : 1)
+                .OrderBy(item => ItemsToGather.Any(toGather => toGather.Item == item) ? 0 : 1)
                 .ToList();
 
             //Gather crystals when using The Giving Land
@@ -97,13 +97,13 @@ namespace GatherBuddy.AutoGather
 
             var shouldGather = aviable
                 //Item is in gathering list
-                .Where(item => ItemsToGather.Any(g => g.ItemId == item.ItemId))
+                .Where(item => ItemsToGather.Any(g => g.Item == item))
                 //And we need more of it
                 .Where(item => InventoryCount(item) < QuantityTotal(item));
 
             var originalItem = desiredItem;
 
-            if (aviable.Any(item => item.ItemId == originalItem.ItemId))
+            if (originalItem != null && aviable.Any(item => item == originalItem))
             {
                 if (InventoryCount(originalItem) < QuantityTotal(originalItem))
                 {

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -78,7 +78,7 @@ namespace GatherBuddy.AutoGather
                 .Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault)
                 .Where((item, index) => item != null && CheckItemOvercap(item, index))
                 .Select(item => item!)
-                .ToArray();
+                .ToList();
 
             var crystals = aviable
                 .Where(IsCrystal)
@@ -86,7 +86,7 @@ namespace GatherBuddy.AutoGather
                 .OrderBy(InventoryCount)
                 //Prioritize crystals in the gathering list
                 .OrderBy(item => ItemsToGather.Any(toGather => toGather.ItemId == item.ItemId) ? 0 : 1)
-                .ToArray();
+                .ToList();
 
             //Gather crystals when using The Giving Land
             if (crystals.Any() && (HasGivingLandBuff || GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown && ShouldUseGivingLand(crystals.First())))
@@ -152,7 +152,7 @@ namespace GatherBuddy.AutoGather
             if (IsTreasureMap(item) && InventoryCount(item) != 0)
                 return false;
             //If it's a crystal, we can't have more than 9999
-            if (IsCrystal(item) && InventoryCount(item) > 9999 - GetCurrentYield(index))
+            if (IsCrystal(item) && InventoryCount(item) > 9999 - GetCurrentYield(index, false))
                 return false;
             return true;
         }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -22,7 +22,7 @@ namespace GatherBuddy.AutoGather
 {
     public partial class AutoGather
     {
-        private unsafe void InteractWithNode(IGameObject gameObject, Gatherable targetItem)
+        private unsafe void EnqueueNodeInteraction(IGameObject gameObject, Gatherable targetItem)
         {
             if (!CanAct)
                 return;
@@ -35,7 +35,7 @@ namespace GatherBuddy.AutoGather
             {
                 targetSystem->OpenObjectInteraction((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)gameObject.Address);
             });
-            TaskManager.DelayNext(1000);
+            TaskManager.DelayNext(500);
         }
 
         private unsafe void DoGatherWindowTasks(IGatherable item)

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -147,10 +147,10 @@ namespace GatherBuddy.AutoGather
                 {
                     desiredItem = aviable.First(item => !IsTreasureMap(item));
                 }
-                //Last resort, gather anything. May overcap
+                //Abort if there are no items we can gather
                 else
                 {
-                    desiredItem = ids.Select(GatherBuddy.GameData.Gatherables.GetValueOrDefault).Where(item => item != null).First()!;
+                    throw new NoGatherableItemsInNodeExceptions();
                 }
                 return false;
             }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -63,20 +63,8 @@ namespace GatherBuddy.AutoGather
         }
 
         private unsafe uint[] GetGatherableIds()
-        {
-            uint[] ids = GatheringAddon->ItemIds.ToArray();
-            foreach (var id in ids)
-            {
-                var gatherable = GatherBuddy.GameData.Gatherables.FirstOrDefault(it => it.Key == id).Value;
-                if (GatherBuddy.UptimeManager.TimedGatherables.Contains(gatherable) && gatherable.NodeType != NodeType.Ephemeral && !TimedNodesGatheredThisTrip.Contains(gatherable.ItemId))
-                {
-                    GatherBuddy.Log.Information($"Saw timed item {gatherable.Name[GatherBuddy.Language]} in node. We should remember that.");
-                    TimedNodesGatheredThisTrip.Add(gatherable.ItemId);
-                }
-            }
+            => GatheringAddon->ItemIds.ToArray();
 
-            return ids;
-        }
         private int GetIndexOfItemToClick(uint[] ids, IGatherable item)
             => ids.IndexOf(item.ItemId);
 

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -27,7 +27,7 @@ namespace GatherBuddy.AutoGather
             TaskManager.Enqueue(() => !Dalamud.Conditions[ConditionFlag.InFlight] && CanAct, 1000, "Wait for not in flight");
             TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) am->UseAction(ActionType.Mount, 0); }, "Dismount 2");
             TaskManager.Enqueue(() => !Dalamud.Conditions[ConditionFlag.Mounted] && CanAct, 1000, "Wait for dismount");
-            TaskManager.Enqueue(() => { if (!Dalamud.Conditions[ConditionFlag.Mounted]) TaskManager.DelayNextImmediate(350); } );//Prevent "Unable to execute command while jumping."
+            TaskManager.Enqueue(() => { if (!Dalamud.Conditions[ConditionFlag.Mounted]) TaskManager.DelayNextImmediate(500); } );//Prevent "Unable to execute command while jumping."
         }
 
         private unsafe void EnqueueMountUp()

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -170,7 +170,7 @@ namespace GatherBuddy.AutoGather
 
         private void Navigate(Vector3 destination, bool shouldFly)
         {
-            if (CurrentDestination == destination)
+            if (CurrentDestination == destination && (IsPathing || IsPathGenerating))
                 return;
             
             StopNavigation();

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -233,12 +233,12 @@ namespace GatherBuddy.AutoGather
         private void MoveToTerritory(ILocation location)
         {
             TaskManager.EnqueueImmediate(() => _plugin.Executor.GatherLocation(location));
-            if (location.Id != Svc.ClientState.TerritoryType)
+            if (location.Territory.Id != Svc.ClientState.TerritoryType)
             {
                 TaskManager.Enqueue(() => Svc.Condition[ConditionFlag.BetweenAreas]);
                 TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.BetweenAreas]);
-                TaskManager.DelayNext(1500);
             }
+            TaskManager.DelayNext(1500);
         }
 
         private Vector3? advandedLastPosition = null;

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -95,7 +95,7 @@ namespace GatherBuddy.AutoGather
                     Vector3 floorPoint;
                     try
                     {
-                        floorPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(Player.Position, 1f, 1f);
+                        floorPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(Player.Position, false, 1f);
                         GatherBuddy.Log.Debug($"Got floor point {floorPoint} from vnavmesh while trying to land");
                     }
                     catch

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -263,8 +263,6 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        public List<Vector3> FarNodesSeenSoFar = new();
-
         private void MoveToFarNode(Vector3 position)
         {
             var farNode = position;

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -36,7 +36,7 @@ namespace GatherBuddy.AutoGather
             var mount = GatherBuddy.Config.AutoGatherConfig.AutoGatherMountId;
             Action doMount;
 
-            if (IsMountUnlocked(mount) && am->GetActionStatus(ActionType.Mount, mount) != 0)
+            if (IsMountUnlocked(mount) && am->GetActionStatus(ActionType.Mount, mount) == 0)
             {
                 doMount = () => am->UseAction(ActionType.Mount, mount);
             }

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -34,7 +34,7 @@ namespace GatherBuddy.AutoGather
         {
             var am = ActionManager.Instance();
             var mount = GatherBuddy.Config.AutoGatherConfig.AutoGatherMountId;
-            Func<bool?> doMount;
+            Action doMount;
 
             if (IsMountUnlocked(mount) && am->GetActionStatus(ActionType.Mount, mount) != 0)
             {

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -33,23 +33,25 @@ namespace GatherBuddy.AutoGather
         private unsafe void EnqueueMountUp()
         {
             var am = ActionManager.Instance();
-
             var mount = GatherBuddy.Config.AutoGatherConfig.AutoGatherMountId;
-            if (am->GetActionStatus(ActionType.Mount, mount) != 0)
-                return;
+            Func<bool?> doMount;
 
-            if (!IsMountUnlocked(mount))
+            if (IsMountUnlocked(mount) && am->GetActionStatus(ActionType.Mount, mount) != 0)
+            {
+                doMount = () => am->UseAction(ActionType.Mount, mount);
+            }
+            else
             {
                 if (am->GetActionStatus(ActionType.GeneralAction, 24) != 0)
                 {
                     return;
                 }
 
-                mount = 24;
+                doMount = () => am->UseAction(ActionType.GeneralAction, 24);
             }
 
             TaskManager.Enqueue(StopNavigation);
-            TaskManager.Enqueue(() => am->UseAction(ActionType.Mount, mount));
+            TaskManager.Enqueue(doMount);
             TaskManager.Enqueue(() => Svc.Condition[ConditionFlag.Mounted], 2000);
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -90,17 +90,6 @@ namespace GatherBuddy.AutoGather
             var distance = Vector3.Distance(Player.Position, gameObject.Position);
             if (distance < 3)
             {
-                if (!Dalamud.Conditions[ConditionFlag.Gathering]
-                 && (targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectable
-                     || !targetItem.ItemData.IsCollectable
-                     && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForGathering))
-                {
-                    if (IsPathing || IsPathGenerating)
-                        VNavmesh_IPCSubscriber.Path_Stop();
-                    AutoStatus = "Waiting for GP to regenerate...";
-                    return;
-                }
-
                 if (Dalamud.Conditions[ConditionFlag.InFlight] && GatherBuddy.Config.AutoGatherConfig.UseExperimentalNavigation)
                 {
                     Vector3 floorPoint;
@@ -126,6 +115,17 @@ namespace GatherBuddy.AutoGather
                     TaskManager.Enqueue(() => VNavmesh_IPCSubscriber.Path_Stop());
                     TaskManager.Enqueue(Dismount);
                     TaskManager.DelayNext(1500);
+                    return;
+                }
+
+                if (!Dalamud.Conditions[ConditionFlag.Gathering]
+                 && (targetItem.ItemData.IsCollectable && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForCollectable
+                     || !targetItem.ItemData.IsCollectable
+                     && Player.Object.CurrentGp < GatherBuddy.Config.AutoGatherConfig.MinimumGPForGathering))
+                {
+                    if (IsPathing || IsPathGenerating)
+                        VNavmesh_IPCSubscriber.Path_Stop();
+                    AutoStatus = "Waiting for GP to regenerate...";
                     return;
                 }
 

--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -35,11 +35,6 @@ public partial class AutoGather
 
     unsafe void DoMateriaExtraction()
     {
-        if (Svc.Condition[ConditionFlag.Mounted])
-        {
-            TaskManager.Enqueue(Dismount);
-            TaskManager.DelayNext(1500);
-        }
         if (MaterializeAddon == null)
         {
             TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
@@ -48,12 +43,13 @@ public partial class AutoGather
             return;
         }
 
-        for (var i = SpiritBondMax; i > 0; i--)
+        TaskManager.Enqueue(() => Callback.Fire(&MaterializeAddon->AtkUnitBase, true, 2, 0));
+        TaskManager.DelayNext(1000);
+        TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39]);
+
+        if (SpiritBondMax == 1) 
         {
-            TaskManager.Enqueue(() => Callback.Fire(&MaterializeAddon->AtkUnitBase, true, 2, 0));
-            TaskManager.DelayNext(1000);
-            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39]);
+            TaskManager.Enqueue(() => MaterializeAddon == null || MaterializeAddon->Close(true));
         }
-        //TaskManager.Enqueue(() => ActionManager.Instance()->UseAction(ActionType.GeneralAction, 14));
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -37,6 +37,7 @@ public partial class AutoGather
     {
         if (MaterializeAddon == null)
         {
+            TaskManager.Enqueue(VNavmesh_IPCSubscriber.Nav_PathfindCancelAll);
             TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
             TaskManager.Enqueue(() => ActionManager.Instance()->UseAction(ActionType.GeneralAction, 14));
             TaskManager.Enqueue(() => MaterializeAddon != null);

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -138,7 +138,7 @@ namespace GatherBuddy.AutoGather
                         }
                         VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                         VNavmesh_IPCSubscriber.Path_Stop();
-                        VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(node.Position, GatherBuddy.AutoGather.ShouldFly);
+                        VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(node.Position, GatherBuddy.AutoGather.ShouldFly(node.Position));
                     }
 
                     var offset = WorldData.NodeOffsets.FirstOrDefault(o => o.Original == node.Position);
@@ -159,7 +159,7 @@ namespace GatherBuddy.AutoGather
                             }
                             VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                             VNavmesh_IPCSubscriber.Path_Stop();
-                            VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(offset.Offset, GatherBuddy.AutoGather.ShouldFly);
+                            VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(offset.Offset, GatherBuddy.AutoGather.ShouldFly(offset.Offset));
                         }
                     }
                     else

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -136,6 +136,7 @@ namespace GatherBuddy.AutoGather
                             Communicator.PrintError("[GatherBuddyReborn] Auto-Gather is enabled! Unable to navigate.");
                             return;
                         }
+                        VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                         VNavmesh_IPCSubscriber.Path_Stop();
                         VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(node.Position, GatherBuddy.AutoGather.ShouldFly);
                     }
@@ -156,6 +157,7 @@ namespace GatherBuddy.AutoGather
                                 Communicator.PrintError("[GatherBuddyReborn] Auto-Gather is enabled! Unable to navigate.");
                                 return;
                             }
+                            VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                             VNavmesh_IPCSubscriber.Path_Stop();
                             VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(offset.Offset, GatherBuddy.AutoGather.ShouldFly);
                         }

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -235,20 +235,17 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossibleCordials.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossibleCordials);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable((rowid > 100000 ? " " : "") + $"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
-                    }
-                    if (item.CanBeHq)
-                    {
-                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId == item.RowId + 100000))
-                        {
-                            GatherBuddy.Config.AutoGatherConfig.CordialConfig.ItemId = item.RowId + 100000;
-                            GatherBuddy.Config.Save();
-                        }
                     }
                 }
 
@@ -271,20 +268,17 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossibleFoods.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossibleFoods);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable((rowid > 100000 ? " " : "") + $"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
-                    }
-                    if (item.CanBeHq)
-                    {
-                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId == item.RowId + 100000))
-                        {
-                            GatherBuddy.Config.AutoGatherConfig.FoodConfig.ItemId = item.RowId + 100000;
-                            GatherBuddy.Config.Save();
-                        }
                     }
                 }
 
@@ -307,20 +301,17 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossiblePotions.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossiblePotions);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable((rowid > 100000 ? " " : "") + $"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
-                    }
-                    if (item.CanBeHq)
-                    {
-                        if (ImGui.Selectable($" {item.Name} ({AutoGather.GetInventoryItemCount(item.RowId + 100000)})", GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId == item.RowId + 100000))
-                        {
-                            GatherBuddy.Config.AutoGatherConfig.PotionConfig.ItemId = item.RowId + 100000;
-                            GatherBuddy.Config.Save();
-                        }
                     }
                 }
 
@@ -341,11 +332,16 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossibleManuals.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossibleManuals);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable((rowid > 100000 ? " " : "") + $"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.ManualConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
                     }
                 }
@@ -367,11 +363,16 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossibleSquadronManuals.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossibleSquadronManuals);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable((rowid > 100000 ? " " : "") + $"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.SquadronManualConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
                     }
                 }
@@ -393,11 +394,16 @@ namespace GatherBuddy.AutoGather
                     GatherBuddy.Config.Save();
                 }
 
-                foreach (var item in AutoGather.PossibleSquadronPasses.OrderBy(item => item.Name.ToString()))
+                var items = PrepareConsumablesList(AutoGather.PossibleSquadronPasses);
+                bool? separatorState = null;
+
+                foreach (var (name, rowid, count) in items)
                 {
-                    if (ImGui.Selectable($"{item.Name} ({AutoGather.GetInventoryItemCount(item.RowId)})", GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId == item.RowId))
+                    DrawConsumablesSeparator(ref separatorState, count == 0);
+
+                    if (ImGui.Selectable($"{name} ({count})", GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId == rowid))
                     {
-                        GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId = item.RowId;
+                        GatherBuddy.Config.AutoGatherConfig.SquadronPassConfig.ItemId = rowid;
                         GatherBuddy.Config.Save();
                     }
                 }
@@ -405,5 +411,25 @@ namespace GatherBuddy.AutoGather
                 ImGui.EndCombo();
             }
         }
+        private static unsafe IOrderedEnumerable<(string name, uint rowid, int count)> PrepareConsumablesList(IEnumerable<Item> items)
+        {
+            return items.SelectMany(item => new[] { (item, rowid: item.RowId), (item, rowid: item.RowId + 100000) })
+                        .Where(t => t.item.CanBeHq || t.rowid < 100000)
+                        .Select(t => (name: t.item.Name.ToString(), t.rowid, count: AutoGather.GetInventoryItemCount(t.rowid)))
+                        .OrderBy(t => t.count == 0)
+                        .ThenBy(t => t.name);
+        }
+
+        private static void DrawConsumablesSeparator(ref bool? canDraw, bool drawNow)
+        {
+            if (!drawNow)
+                canDraw = true;
+            else if (canDraw.GetValueOrDefault())
+            {
+                ImGui.Separator();
+                canDraw = false;
+            }
+        }
+
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -156,7 +156,7 @@ namespace GatherBuddy.AutoGather
                 if (InventoryCount(item) >= QuantityTotal(item) || IsTreasureMap(item) && InventoryCount(item) > 0)
                     continue;
 
-                if (IsTreasureMap(item) && NextTresureMapAllowance >= GatherBuddy.Time.ServerTime.AddSeconds(-GatherBuddy.Config.AutoGatherConfig.TimedNodePrecog).DateTime)
+                if (IsTreasureMap(item) && NextTresureMapAllowance >= GatherBuddy.Time.ServerTime.AddSeconds(GatherBuddy.Config.AutoGatherConfig.TimedNodePrecog).DateTime)
                     continue;
 
                 if (GatherBuddy.UptimeManager.TimedGatherables.Contains(item))

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -149,8 +149,6 @@ namespace GatherBuddy.AutoGather
 
         public void UpdateItemsToGather()
         {
-            if (IsGathering)
-                return;
             TimedItemsToGather.Clear();
             ItemsToGather.Clear();
             List<IGatherable> activeItems = OrderActiveItems(_plugin.GatherWindowManager.ActiveItems).ToList();

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -45,8 +45,7 @@ namespace GatherBuddy.AutoGather
             => Dalamud.Conditions[ConditionFlag.Gathering] || Dalamud.Conditions[ConditionFlag.Gathering42];
 
         public bool?    LastNavigationResult { get; set; } = null;
-        public Vector3? CurrentDestination   { get; set; } = null;
-        public bool     HasSeenFlag          { get; set; } = false;
+        public Vector3 CurrentDestination   { get; private set; } = default;
 
         public GatheringType JobAsGatheringType
         {
@@ -64,17 +63,7 @@ namespace GatherBuddy.AutoGather
         }
 
         public bool ShouldUseFlag
-        {
-            get
-            {
-                if (GatherBuddy.Config.AutoGatherConfig.DisableFlagPathing)
-                    return false;
-                if (HasSeenFlag)
-                    return false;
-
-                return true;
-            }
-        }
+            => GatherBuddy.Config.AutoGatherConfig.DisableFlagPathing;
 
         public unsafe Vector3? MapFlagPosition
         {
@@ -100,18 +89,15 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        public bool ShouldFly
+        public bool ShouldFly(Vector3 destination)
         {
-            get
+            if (GatherBuddy.Config.AutoGatherConfig.ForceWalking || Dalamud.ClientState.LocalPlayer == null)
             {
-                if (GatherBuddy.Config.AutoGatherConfig.ForceWalking)
-                {
-                    return false;
-                }
-
-                return Vector3.Distance(Dalamud.ClientState.LocalPlayer.Position, CurrentDestination ?? Vector3.Zero)
-                 >= GatherBuddy.Config.AutoGatherConfig.MountUpDistance;
+                return false;
             }
+
+            return Vector3.Distance(Dalamud.ClientState.LocalPlayer.Position, destination)
+                >= GatherBuddy.Config.AutoGatherConfig.MountUpDistance;
         }
 
         public unsafe Vector2? TimedNodePosition
@@ -222,6 +208,7 @@ namespace GatherBuddy.AutoGather
                  || Dalamud.Conditions[ConditionFlag.LoggingOut]
                  || Dalamud.Conditions[ConditionFlag.Occupied]
                  || Dalamud.Conditions[ConditionFlag.Unconscious]
+                 || Dalamud.Conditions[ConditionFlag.Gathering42]
                  || Dalamud.ClientState.LocalPlayer.CurrentHp < 1)
                     return false;
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -144,7 +144,9 @@ namespace GatherBuddy.AutoGather
 
         public readonly List<IGatherable> ItemsToGather = [];
         public readonly Dictionary<ILocation, TimeInterval> VisitedTimedLocations = [];
-        public (ILocation? Location, TimeInterval Time) targetLocation = (null, TimeInterval.Invalid);
+        private readonly HashSet<Vector3> FarNodesSeenSoFar = [];
+        private readonly LinkedList<Vector3> VisitedNodes = [];
+        private (ILocation? Location, TimeInterval Time) targetLocation = (null, TimeInterval.Invalid);
 
         public void UpdateItemsToGather()
         {
@@ -272,6 +274,7 @@ namespace GatherBuddy.AutoGather
 
         private static unsafe uint FreeInventorySlots
             => InventoryManager.Instance()->GetEmptySlotsInBag();
+
         private static TimeStamp AdjuctedServerTime
             => GatherBuddy.Time.ServerTime.AddSeconds(GatherBuddy.Config.AutoGatherConfig.TimedNodePrecog);
     }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -183,14 +183,10 @@ namespace GatherBuddy.AutoGather
             => (AddonMaterializeDialog*)Dalamud.GameGui.GetAddonByName("Materialize", 1);
 
         public IEnumerable<IGatherable> ItemsToGatherInZone
-            => ItemsToGather.Where(i => i.Locations.Any(l => l.Territory.Id == Dalamud.ClientState.TerritoryType)).Where(GatherableMatchesJob);
+            => ItemsToGather.Where(i => i.Locations.Any(l => l.Territory.Id == Dalamud.ClientState.TerritoryType)).Where(i => i.Locations.Any(LocationMatchesJob));
 
-        private bool GatherableMatchesJob(IGatherable arg)
-        {
-            var gatherable = arg as Gatherable;
-            return gatherable != null
-             && (gatherable.GatheringType.ToGroup() == JobAsGatheringType || gatherable.GatheringType.ToGroup() == GatheringType.Multiple);
-        }
+        private bool LocationMatchesJob(ILocation loc)
+            => loc.GatheringType.ToGroup() == JobAsGatheringType;
 
         public bool CanAct
         {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -63,7 +63,7 @@ namespace GatherBuddy.AutoGather
         }
 
         public bool ShouldUseFlag
-            => GatherBuddy.Config.AutoGatherConfig.DisableFlagPathing;
+            => !GatherBuddy.Config.AutoGatherConfig.DisableFlagPathing;
 
         public unsafe Vector3? MapFlagPosition
         {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -207,9 +207,11 @@ namespace GatherBuddy.AutoGather
                  || Dalamud.Conditions[ConditionFlag.Jumping61]
                  || Dalamud.Conditions[ConditionFlag.LoggingOut]
                  || Dalamud.Conditions[ConditionFlag.Occupied]
+                 || Dalamud.Conditions[ConditionFlag.Occupied39]
                  || Dalamud.Conditions[ConditionFlag.Unconscious]
                  || Dalamud.Conditions[ConditionFlag.Gathering42]
-                 || Dalamud.ClientState.LocalPlayer.CurrentHp < 1)
+                 || Dalamud.ClientState.LocalPlayer.CurrentHp < 1
+                 || Player.IsAnimationLocked)
                     return false;
 
                 return true;

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -144,8 +144,8 @@ namespace GatherBuddy.AutoGather
 
         public readonly List<IGatherable> ItemsToGather = [];
         public readonly Dictionary<ILocation, TimeInterval> VisitedTimedLocations = [];
-        private readonly HashSet<Vector3> FarNodesSeenSoFar = [];
-        private readonly LinkedList<Vector3> VisitedNodes = [];
+        public readonly HashSet<Vector3> FarNodesSeenSoFar = [];
+        public readonly LinkedList<Vector3> VisitedNodes = [];
         private (ILocation? Location, TimeInterval Time) targetLocation = (null, TimeInterval.Invalid);
 
         public void UpdateItemsToGather()

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -269,5 +269,8 @@ namespace GatherBuddy.AutoGather
 
         private static unsafe DateTime NextTresureMapAllowance
             => FFXIVClientStructs.FFXIV.Client.Game.UI.UIState.Instance()->GetNextMapAllowanceDateTime();
+
+        private static unsafe uint FreeInventorySlots
+            => InventoryManager.Instance()->GetEmptySlotsInBag();
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -264,6 +264,7 @@ namespace GatherBuddy.AutoGather
         private static unsafe bool IsGivingLandOffCooldown
             => ActionManager.Instance()->IsActionOffCooldown(ActionType.Action, Actions.GivingLand.ActionID);
 
+        //Should be near the upper bound to reduce the probability of overcapping.
         private const int GivingLandYeild = 30;
 
         private static unsafe DateTime NextTresureMapAllowance

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -127,6 +127,7 @@ namespace GatherBuddy.AutoGather
         public string AutoStatus { get; set; } = "Idle";
         public int    LastCollectability = 0;
         public int    LastIntegrity      = 0;
+        public bool   HiddenRevealed     = false;
 
         public readonly List<GatherInfo> ItemsToGather = [];
         public readonly Dictionary<ILocation, TimeInterval> VisitedTimedLocations = [];

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -165,6 +165,12 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
+            if (GatherBuddy.Config.AutoGatherConfig.DoMaterialize && !IsPathing && !IsPathGenerating && !IsGathering && !Svc.Condition[ConditionFlag.Mounted] && SpiritBondMax > 0)
+            {
+                DoMateriaExtraction();
+                return;
+            }
+
             if (!IsGathering) UpdateItemsToGather();
             Gatherable? targetItem = ItemsToGather.FirstOrDefault() as Gatherable;
 
@@ -227,12 +233,6 @@ namespace GatherBuddy.AutoGather
             {
                 StuckCheck();
                 AdvancedUnstuckCheck();
-            }
-
-            if (!IsPathing && !Svc.Condition[ConditionFlag.Mounted] && SpiritBondMax > 0 && GatherBuddy.Config.AutoGatherConfig.DoMaterialize)
-            {
-                DoMateriaExtraction();
-                return;
             }
 
             var location = GatherBuddy.UptimeManager.BestLocation(targetItem);

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -71,7 +71,6 @@ namespace GatherBuddy.AutoGather
 
                     TaskManager.Abort();
                     HasSeenFlag                         = false;
-                    HiddenRevealed                      = false;
                     _movementController.Enabled         = false;
                     _movementController.DesiredPosition = Vector3.Zero;
                     ResetNavigation();
@@ -111,6 +110,9 @@ namespace GatherBuddy.AutoGather
 
         public void DoAutoGather()
         {
+            if (!IsGathering)
+                HiddenRevealed = false; //Reset the "Used Luck" flag event if auto-gather was disabled mid-gathering
+
             if (!Enabled)
             {
                 return;
@@ -150,7 +152,7 @@ namespace GatherBuddy.AutoGather
                 AutoStatus = "Player is busy...";
                 return;
             }
-            
+
             UpdateItemsToGather();
             Gatherable? targetItem =
                 (TimedItemsToGather.Count > 0 ? TimedItemsToGather.MinBy(GetNodeTypeAsPriority) : ItemsToGather.FirstOrDefault()) as Gatherable;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -202,6 +202,9 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
+            if (IsGathering)
+                return;
+
             if (IsPathGenerating)
             {
                 AutoStatus = "Generating path...";

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -155,8 +155,7 @@ namespace GatherBuddy.AutoGather
             }
 
             if (!IsGathering) UpdateItemsToGather();
-            Gatherable? targetItem =
-                (TimedItemsToGather.Count > 0 ? TimedItemsToGather.MinBy(GetNodeTypeAsPriority) : ItemsToGather.FirstOrDefault()) as Gatherable;
+            Gatherable? targetItem = ItemsToGather.FirstOrDefault() as Gatherable;
 
             if (targetItem == null)
             {
@@ -189,7 +188,7 @@ namespace GatherBuddy.AutoGather
                 catch (NoGatherableItemsInNodeExceptions)
                 {
                     UpdateItemsToGather();
-                    bool abort = targetItem == (TimedItemsToGather.Count > 0 ? TimedItemsToGather.MinBy(GetNodeTypeAsPriority) : ItemsToGather.FirstOrDefault());
+                    bool abort = targetItem == ItemsToGather.FirstOrDefault();
 
                     //We may stuck in infinite loop attempt to gather the same item, therefore disable auto-gather
                     if (abort)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -241,6 +241,7 @@ namespace GatherBuddy.AutoGather
                 HasSeenFlag = false;
                 TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
                 TaskManager.Enqueue(() => MoveToTerritory(location.Location));
+                AutoStatus = "Teleporting...";
                 return;
             }
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -159,7 +159,7 @@ namespace GatherBuddy.AutoGather
 
             if (targetItem == null)
             {
-                if (!_plugin.GatherWindowManager.ActiveItems.Any(i => InventoryCount(i) < QuantityTotal(i)))
+                if (!_plugin.GatherWindowManager.ActiveItems.Any(i => InventoryCount(i) < QuantityTotal(i) && !(IsTreasureMap(i) && InventoryCount(i) != 0)))
                 {
                     AutoStatus         = "No items to gather...";
                     Enabled            = false;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -218,6 +218,12 @@ namespace GatherBuddy.AutoGather
                 AdvancedUnstuckCheck();
             }
 
+            if (!IsPathing && !Svc.Condition[ConditionFlag.Mounted] && SpiritBondMax > 0 && GatherBuddy.Config.AutoGatherConfig.DoMaterialize)
+            {
+                DoMateriaExtraction();
+                return;
+            }
+
             var location = GatherBuddy.UptimeManager.BestLocation(targetItem);
             if (location.Location.Territory.Id != Svc.ClientState.TerritoryType || !GatherableMatchesJob(targetItem))
             {
@@ -228,11 +234,6 @@ namespace GatherBuddy.AutoGather
             }
 
             DoUseConsumablesWithoutCastTime();
-            if (SpiritBondMax > 0 && GatherBuddy.Config.AutoGatherConfig.DoMaterialize)
-            {
-                DoMateriaExtraction();
-                return;
-            }
 
             var validNodesForItem = targetItem.NodeList.SelectMany(n => n.WorldPositions).ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
             var matchingNodesInZone = location.Location.WorldPositions.Where(w => validNodesForItem.ContainsKey(w.Key)).SelectMany(w => w.Value)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -254,7 +254,7 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (targetLocation.Location.Territory.Id != Svc.ClientState.TerritoryType || !GatherableMatchesJob(targetItem))
+            if (targetLocation.Location.Territory.Id != Svc.ClientState.TerritoryType || !LocationMatchesJob(targetLocation.Location))
             {
                 StopNavigation();
                 MoveToTerritory(targetLocation.Location);

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -70,7 +70,11 @@ namespace GatherBuddy.AutoGather
                     _movementController.DesiredPosition = Vector3.Zero;
                     ResetNavigation();
                     AutoStatus = "Idle...";
-                } 
+                }
+                else
+                {
+                    RefreshNextTresureMapAllowance();
+                }
 
                 _enabled = value;
             }

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -93,11 +93,6 @@ namespace GatherBuddy.AutoGather
 
             if (HousingManager.IsInHousing() || Lifestream_IPCSubscriber.IsBusy())
             {
-                if (SpiritBondMax > 0 && GatherBuddy.Config.AutoGatherConfig.DoMaterialize)
-                {
-                    DoMateriaExtraction();
-                    return;
-                }
                 return;
             }
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -61,6 +61,7 @@ namespace GatherBuddy.AutoGather
 
                     if (IsPathing || IsPathGenerating)
                     {
+                        VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                         VNavmesh_IPCSubscriber.Path_Stop();
                     }
 
@@ -93,6 +94,7 @@ namespace GatherBuddy.AutoGather
 
             if (Lifestream_IPCSubscriber.IsEnabled)
             {
+                TaskManager.Enqueue(VNavmesh_IPCSubscriber.Nav_PathfindCancelAll);
                 TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
                 TaskManager.Enqueue(() => Lifestream_IPCSubscriber.ExecuteCommand("auto"));
                 TaskManager.Enqueue(() => Svc.Condition[ConditionFlag.BetweenAreas]);
@@ -206,6 +208,7 @@ namespace GatherBuddy.AutoGather
                 if (GatherBuddy.Config.AutoGatherConfig.DoGathering)
                 {
                     AutoStatus = "Gathering...";
+                    TaskManager.Enqueue(VNavmesh_IPCSubscriber.Nav_PathfindCancelAll);
                     TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
                     try
                     {
@@ -265,6 +268,7 @@ namespace GatherBuddy.AutoGather
             if (targetLocation.Location.Territory.Id != Svc.ClientState.TerritoryType || !GatherableMatchesJob(targetItem))
             {
                 HasSeenFlag = false;
+                TaskManager.Enqueue(VNavmesh_IPCSubscriber.Nav_PathfindCancelAll);
                 TaskManager.Enqueue(VNavmesh_IPCSubscriber.Path_Stop);
                 TaskManager.Enqueue(() => MoveToTerritory(targetLocation.Location));
                 AutoStatus = "Teleporting...";
@@ -320,6 +324,7 @@ namespace GatherBuddy.AutoGather
                 FarNodesSeenSoFar.Add(selectedNode);
 
                 CurrentDestination = null;
+                VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
                 VNavmesh_IPCSubscriber.Path_Stop();
                 AutoStatus = "Looking for far away nodes...";
                 return;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -183,7 +183,7 @@ namespace GatherBuddy.AutoGather
                     && target.ObjectKind is ObjectKind.GatheringPoint 
                     && targetItem.NodeType is NodeType.Regular or NodeType.Ephemeral 
                     && VisitedNodes.Last?.Value != target.Position
-                    && (targetItem.ExpansionIdx > 0 || targetLocation.Location?.Id >= 397))
+                    && targetLocation.Location?.Territory.Id >= 397)
                 {
                     FarNodesSeenSoFar.Clear();
                     VisitedNodes.AddLast(target.Position);

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -71,10 +71,6 @@ namespace GatherBuddy.AutoGather
                     ResetNavigation();
                     AutoStatus = "Idle...";
                 } 
-                else
-                {
-                    RefreshNextTresureMapAllowance();
-                }
 
                 _enabled = value;
             }
@@ -180,6 +176,7 @@ namespace GatherBuddy.AutoGather
             if (IsTreasureMap(targetItem) && NextTresureMapAllowance == DateTime.MinValue)
             {
                 //Wait for timer refresh
+                RefreshNextTresureMapAllowance();
                 return;
             }
 

--- a/GatherBuddy/CustomInfo/FuzzyVector3.cs
+++ b/GatherBuddy/CustomInfo/FuzzyVector3.cs
@@ -29,7 +29,7 @@ namespace GatherBuddy.CustomInfo
             {
                 try
                 {
-                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(vector, distance, distance);
+                    var nearestPoint = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(vector, false, distance);
                     if (!nearestPoint.SanityCheck())
                         return vector;
 

--- a/GatherBuddy/GatherHelper/GatherWindowManager.ManipPreset.cs
+++ b/GatherBuddy/GatherHelper/GatherWindowManager.ManipPreset.cs
@@ -107,6 +107,8 @@ public partial class GatherWindowManager
             quantity = 1;
         if (quantity > 9999)
             quantity = 9999;
+        if (GatherBuddy.GameData.Gatherables[itemId].ItemData.FilterGroup == 18)
+            quantity = 1;
         
         preset.Quantities[itemId] = quantity;
         Save();

--- a/GatherBuddy/GatherHelper/GatherWindowManager.ManipPreset.cs
+++ b/GatherBuddy/GatherHelper/GatherWindowManager.ManipPreset.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Collections.Generic;
+using GatherBuddy.Classes;
 using GatherBuddy.Interfaces;
 using GatherBuddy.Plugin;
 
@@ -124,5 +125,32 @@ public partial class GatherWindowManager
         Save();
         if (preset.Enabled)
             SetActiveItems();
+    }
+
+    public void ChangePreferredLocation(GatherWindowPreset preset, IGatherable item, ILocation? location)
+    {
+        if (item is not Gatherable) return;
+
+        if (location is not GatheringNode)
+            preset.PreferredLocations.Remove(item.ItemId);
+        else
+            preset.PreferredLocations[item.ItemId] = location.Id;
+        
+        Save();
+    }
+
+    public GatheringNode? GetPreferredLocation(Gatherable item)
+    {
+        foreach (var preset in Presets)
+        {
+            if (preset.Enabled)
+            {
+                if (preset.PreferredLocations.TryGetValue(item.ItemId, out var locId))
+                {
+                    return GatherBuddy.GameData.GatheringNodes.GetValueOrDefault(locId);
+                }
+            }
+        }
+        return null;
     }
 }

--- a/GatherBuddy/GatherHelper/GatherWindowPreset.cs
+++ b/GatherBuddy/GatherHelper/GatherWindowPreset.cs
@@ -14,11 +14,12 @@ namespace GatherBuddy.GatherHelper;
 
 public class GatherWindowPreset
 {
-    public List<IGatherable>      Items       { get; init; } = new();
-    public Dictionary<uint, uint> Quantities  { get; set; } = new();
-    public string                 Name        { get; set; }  = string.Empty;
-    public string                 Description { get; set; }  = string.Empty;
-    public bool                   Enabled     { get; set; }  = false;
+    public List<IGatherable>      Items              { get; init; } = new();
+    public Dictionary<uint, uint> Quantities         { get; set; } = new();
+    public Dictionary<uint, uint> PreferredLocations { get; set; } = new();
+    public string                 Name               { get; set; }  = string.Empty;
+    public string                 Description        { get; set; }  = string.Empty;
+    public bool                   Enabled            { get; set; }  = false;
 
     public GatherWindowPreset Clone()
         => new()
@@ -49,18 +50,20 @@ public class GatherWindowPreset
         public uint[]        ItemIds;
         public ObjectType[]  ItemTypes;
         public Dictionary<uint, uint> Quantities;
+        public Dictionary<uint, uint> PrefferedLocations;
         public string        Name;
         public string        Description;
         public bool          Enabled;
 
         public Config(GatherWindowPreset preset)
         {
-            ItemIds     = preset.Items.Select(i => i.ItemId).ToArray();
-            ItemTypes   = preset.Items.Select(i => i.Type).ToArray();
-            Quantities  = preset.Quantities;
-            Name        = preset.Name;
-            Description = preset.Description;
-            Enabled     = preset.Enabled;
+            ItemIds            = preset.Items.Select(i => i.ItemId).ToArray();
+            ItemTypes          = preset.Items.Select(i => i.Type).ToArray();
+            Quantities         = preset.Quantities;
+            PrefferedLocations = preset.PreferredLocations;
+            Name               = preset.Name;
+            Description        = preset.Description;
+            Enabled            = preset.Enabled;
         }
 
         internal string ToBase64()
@@ -82,7 +85,7 @@ public class GatherWindowPreset
 
                 var json = Encoding.UTF8.GetString(bytes.AsSpan()[1..]);
                 cfg = JsonConvert.DeserializeObject<Config>(json);
-                if (cfg.ItemIds == null || cfg.ItemTypes == null || cfg.Name == null || cfg.Description == null || cfg.Quantities == null)
+                if (cfg.ItemIds == null || cfg.ItemTypes == null || cfg.Name == null || cfg.Description == null || cfg.Quantities == null || cfg.PrefferedLocations == null)
                     return false;
 
                 return true;
@@ -113,6 +116,7 @@ public class GatherWindowPreset
                 _                     => null,
             };
             ret.Quantities = cfg.Quantities;
+            ret.PreferredLocations = cfg.PrefferedLocations;
             if (gatherable == null)
                 changes = true;
             else if (!ret.Add(gatherable))

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -177,13 +177,13 @@ public partial class Interface
         }
 
         public static void DrawBYIIBox()
-            => DrawCheckbox("Use BYII", "Toggle whether to use BYII for gathering.", GatherBuddy.Config.AutoGatherConfig.BYIIConfig.UseAction,
+            => DrawCheckbox("Use Bountiful Yield/Harvest II", "Toggle whether to use Bountiful Yield/Harvest II for gathering.", GatherBuddy.Config.AutoGatherConfig.BYIIConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.BYIIConfig.UseAction = b);
 
         public static void DrawBYIIMinGP()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BYIIConfig.MinimumGP;
-            if (ImGui.DragInt("BYII Min GP", ref tmp, 1, 100, 30000))
+            if (ImGui.DragInt("Bountiful Yield/Harvest II Min GP", ref tmp, 1, 100, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.BYIIConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -193,7 +193,7 @@ public partial class Interface
         public static void DrawBYIIMaxGP()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BYIIConfig.MaximumGP;
-            if (ImGui.DragInt("BYII Max GP", ref tmp, 1, 100, 30000))
+            if (ImGui.DragInt("Bountiful Yield/Harvest II Max GP", ref tmp, 1, 100, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.BYIIConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -394,12 +394,12 @@ public partial class Interface
 
 
         public static void DrawYieldIICheckbox()
-            => DrawCheckbox("Use Kings Yield/Bountiful Harvest II", "Use these actions when available",
+            => DrawCheckbox("Use Kings Yield/Blessed Harvest II", "Use these actions when available",
                 GatherBuddy.Config.AutoGatherConfig.YieldIIConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.YieldIIConfig.UseAction = b);
 
         public static void DrawYieldICheckbox()
-            => DrawCheckbox("Use Kings Yield/Bountiful Harvest I", "Use these actions when available",
+            => DrawCheckbox("Use Kings Yield/Blessed Harvest I", "Use these actions when available",
                 GatherBuddy.Config.AutoGatherConfig.YieldIConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.YieldIConfig.UseAction = b);
 
@@ -408,7 +408,7 @@ public partial class Interface
                 b => GatherBuddy.Config.AutoGatherConfig.ScrutinyConfig.UseAction = b);
 
         public static void DrawMeticulousCheckbox()
-            => DrawCheckbox("Use Meticulous", "Use Meticulous to gather collectibles",
+            => DrawCheckbox("Use Meticulous Prospector", "Use Meticulous Prospector to gather collectibles",
                 GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.UseAction = b);
 
@@ -418,17 +418,17 @@ public partial class Interface
                 b => GatherBuddy.Config.AutoGatherConfig.ScourConfig.UseAction = b);
 
         public static void DrawBrazenCheckbox()
-            => DrawCheckbox("Use Brazen", "Use Brazen to gather collectibles when appropriate",
+            => DrawCheckbox("Use Brazen Prospector", "Use Brazen Prospector to gather collectibles when appropriate",
                 GatherBuddy.Config.AutoGatherConfig.BrazenConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.BrazenConfig.UseAction = b);
 
         public static void DrawSolidAgeCollectablesCheckbox()
-            => DrawCheckbox("Use Solid/Age (Collectibles)", "Use Solid/Age to gather collectibles",
+            => DrawCheckbox("Use Solid Reason/Ageless Words (Collectibles)", "Use Solid Reason/Ageless Words to gather collectibles",
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.UseAction = b);
 
         public static void DrawSolidAgeGatherablesCheckbox()
-            => DrawCheckbox("Use Solid/Age (Gatherables)", "Use Solid/Age to gather collectibles",
+            => DrawCheckbox("Use Solid Reason/Ageless Words (Gatherables)", "Use Solid Reason/Ageless Words to gather collectibles",
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.UseAction,
                 b => GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.UseAction = b);
 
@@ -462,7 +462,7 @@ public partial class Interface
         public static void DrawMeticulousMaxGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MaximumGP;
-            if (ImGui.DragInt("Meticulous Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
+            if (ImGui.DragInt("Meticulous Prospector Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -482,7 +482,7 @@ public partial class Interface
         public static void DrawBrazenMaxGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MaximumGP;
-            if (ImGui.DragInt("Brazen Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
+            if (ImGui.DragInt("Brazen Prospector Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -492,7 +492,7 @@ public partial class Interface
         public static void DrawSolidAgeCollectablesMaxGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.MaximumGP;
-            if (ImGui.DragInt("Solid/Age Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
+            if (ImGui.DragInt("Solid Reason/Ageless Words Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -502,7 +502,7 @@ public partial class Interface
         public static void DrawSolidAgeGatherablesMaxGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.MaximumGP;
-            if (ImGui.DragInt("Solid/Age Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
+            if (ImGui.DragInt("Solid Reason/Ageless Words Max GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.MaximumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -545,7 +545,7 @@ public partial class Interface
         public static void DrawMeticulousMinGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP;
-            if (ImGui.DragInt("Meticulous Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
+            if (ImGui.DragInt("Meticulous Prospector Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Meticulous.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.MeticulousConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -565,7 +565,7 @@ public partial class Interface
         public static void DrawBrazenMinGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MinimumGP;
-            if (ImGui.DragInt("Brazen Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
+            if (ImGui.DragInt("Brazen Prospector Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.Brazen.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.BrazenConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -575,7 +575,7 @@ public partial class Interface
         public static void DrawSolidAgeCollectablesMinGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.MinimumGP;
-            if (ImGui.DragInt("Solid/Age Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
+            if (ImGui.DragInt("Solid Reason/Ageless Words Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeCollectablesConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -585,7 +585,7 @@ public partial class Interface
         public static void DrawSolidAgeGatherablesMinGp()
         {
             int tmp = (int)GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.MinimumGP;
-            if (ImGui.DragInt("Solid/Age Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
+            if (ImGui.DragInt("Solid Reason/Ageless Words Min GP", ref tmp, 1, AutoGather.AutoGather.Actions.SolidAge.GpCost, 30000))
             {
                 GatherBuddy.Config.AutoGatherConfig.SolidAgeGatherablesConfig.MinimumGP = (uint)tmp;
                 GatherBuddy.Config.Save();
@@ -1210,7 +1210,7 @@ public partial class Interface
 
             if (ImGui.TreeNodeEx("Gathering Actions"))
             {
-                if (ImGui.TreeNodeEx("Bountiful Yield"))
+                if (ImGui.TreeNodeEx("Bountiful Yield/Harvest II"))
                 {
                     ConfigFunctions.DrawBYIIBox();
                     ConfigFunctions.DrawBYIIMinGP();
@@ -1220,7 +1220,7 @@ public partial class Interface
                     ImGui.TreePop();
                 }
 
-                if (ImGui.TreeNodeEx("Kings Yield/Bountiful Harvest II"))
+                if (ImGui.TreeNodeEx("Kings Yield/Blessed Harvest II"))
                 {
                     ConfigFunctions.DrawYieldIICheckbox();
                     ConfigFunctions.DrawYieldIIMinGP();
@@ -1230,7 +1230,7 @@ public partial class Interface
                     ImGui.TreePop();
                 }
 
-                if (ImGui.TreeNodeEx("Kings Yield/Bountiful Harvest I"))
+                if (ImGui.TreeNodeEx("Kings Yield/Blessed Harvest I"))
                 {
                     ConfigFunctions.DrawYieldICheckbox();
                     ConfigFunctions.DrawYieldIMinGP();
@@ -1240,7 +1240,7 @@ public partial class Interface
                     ImGui.TreePop();
                 }
 
-                if (ImGui.TreeNodeEx("Solid/Age"))
+                if (ImGui.TreeNodeEx("Solid Reason/Ageless Words"))
                 {
                     ConfigFunctions.DrawSolidAgeGatherablesCheckbox();
                     ConfigFunctions.DrawSolidAgeGatherablesMinGp();
@@ -1281,22 +1281,6 @@ public partial class Interface
 
             if (ImGui.TreeNodeEx("Collectible actions"))
             {
-                if (ImGui.TreeNodeEx("Scrutiny"))
-                {
-                    ConfigFunctions.DrawScrutinyCheckbox();
-                    ConfigFunctions.DrawScrutinyMinGp();
-                    ConfigFunctions.DrawScrutinyMaxGp();
-                    ImGui.TreePop();
-                }
-
-                if (ImGui.TreeNodeEx("Meticulous"))
-                {
-                    ConfigFunctions.DrawMeticulousCheckbox();
-                    ConfigFunctions.DrawMeticulousMinGp();
-                    ConfigFunctions.DrawMeticulousMaxGp();
-                    ImGui.TreePop();
-                }
-
                 if (ImGui.TreeNodeEx("Scour"))
                 {
                     ConfigFunctions.DrawScourCheckbox();
@@ -1305,7 +1289,7 @@ public partial class Interface
                     ImGui.TreePop();
                 }
 
-                if (ImGui.TreeNodeEx("Brazen"))
+                if (ImGui.TreeNodeEx("Brazen Prospector"))
                 {
                     ConfigFunctions.DrawBrazenCheckbox();
                     ConfigFunctions.DrawBrazenMinGp();
@@ -1313,7 +1297,23 @@ public partial class Interface
                     ImGui.TreePop();
                 }
 
-                if (ImGui.TreeNodeEx("Solid/Age"))
+                if (ImGui.TreeNodeEx("Meticulous Prospector"))
+                {
+                    ConfigFunctions.DrawMeticulousCheckbox();
+                    ConfigFunctions.DrawMeticulousMinGp();
+                    ConfigFunctions.DrawMeticulousMaxGp();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Scrutiny"))
+                {
+                    ConfigFunctions.DrawScrutinyCheckbox();
+                    ConfigFunctions.DrawScrutinyMinGp();
+                    ConfigFunctions.DrawScrutinyMaxGp();
+                    ImGui.TreePop();
+                }
+
+                if (ImGui.TreeNodeEx("Solid Reason/Ageless Words"))
                 {
                     ConfigFunctions.DrawSolidAgeCollectablesCheckbox();
                     ConfigFunctions.DrawSolidAgeCollectablesMinGp();

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -68,10 +68,6 @@ public partial class Interface
         public static void DrawGoHomeBox()
             => DrawCheckbox("Go home when idle", "Uses the '/li auto' command to take you home when done gathering or waiting for timed nodes",
                 GatherBuddy.Config.AutoGatherConfig.GoHomeWhenIdle, b => GatherBuddy.Config.AutoGatherConfig.GoHomeWhenIdle = b);
-        public static void DrawAdvancedNavBox()
-            => DrawCheckbox("Enable Experimental Navigation", "Use advanced navigation techniques to try and work around vnavmesh limitations",
-                GatherBuddy.Config.AutoGatherConfig.UseExperimentalNavigation,
-                b => GatherBuddy.Config.AutoGatherConfig.UseExperimentalNavigation = b);
 
         public static void DrawAdvancedUnstuckBox()
             => DrawCheckbox("Enable Experimental Unstuck Method",
@@ -1386,7 +1382,6 @@ public partial class Interface
                 ConfigFunctions.DrawAutoGatherBox();
                 ConfigFunctions.DrawUseFlagBox();
                 ConfigFunctions.DrawForceWalkingBox();
-                ConfigFunctions.DrawAdvancedNavBox();
                 ConfigFunctions.DrawAdvancedUnstuckBox();
                 ConfigFunctions.DrawMaterialExtraction();
                 ConfigFunctions.DrawAntiStuckCooldown();

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -616,15 +616,7 @@ public partial class Interface
             }
         }
 
-        if (ImGui.CollapsingHeader("Timed Nodes To Gather"))
-        {
-            foreach (var item in GatherBuddy.AutoGather.TimedItemsToGather)
-            {
-                ImGui.Text(item.Name[GatherBuddy.Language]);
-            }
-        }
-
-        if (ImGui.CollapsingHeader("Static Nodes to Gather"))
+        if (ImGui.CollapsingHeader("Nodes to Gather"))
         {
             foreach (var item in GatherBuddy.AutoGather.ItemsToGather)
             {

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -634,7 +634,7 @@ public partial class Interface
         {
             foreach (var item in GatherBuddy.AutoGather.ItemsToGather)
             {
-                ImGui.Text(item.Name[GatherBuddy.Language]);
+                ImGui.Text(item.Item.Name[GatherBuddy.Language]);
             }
         }
 

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -131,8 +131,8 @@ public partial class Interface
                 _weatherTable.SetDirty();
             if (ImGui.Button("Set Locations Dirty"))
                 GatherBuddy.UptimeManager.ResetLocations();
-                }
-            }
+        }
+    }
 
     private static unsafe void DrawDebugTime()
     {
@@ -587,7 +587,6 @@ public partial class Interface
         ImGui.Text($"Status: {GatherBuddy.AutoGather.AutoStatus}");
         ImGui.Text($"Navigation: {GatherBuddy.AutoGather.LastNavigationResult}");
         ImGui.Text($"Current Destination: {GatherBuddy.AutoGather.CurrentDestination}");
-        ImGui.Text($"ShouldFly: {GatherBuddy.AutoGather.ShouldFly}");
         ImGui.Text($"IsGathering: {GatherBuddy.AutoGather.IsGathering}");
         ImGui.Text($"IsPathing: {GatherBuddy.AutoGather.IsPathing}");
         ImGui.Text($"IsPathGenerating: {GatherBuddy.AutoGather.IsPathGenerating}");
@@ -597,7 +596,6 @@ public partial class Interface
         ImGui.Text($"ItemsToGatherInZone: {GatherBuddy.AutoGather.ItemsToGatherInZone.Count()}");
         ImGui.Text($"ItemsToGather: {GatherBuddy.AutoGather.ItemsToGather.Count()}");
         ImGui.Text($"ShouldUseFlag: {GatherBuddy.AutoGather.ShouldUseFlag}");
-        ImGui.Text(($"HasSeenFlag: {GatherBuddy.AutoGather.HasSeenFlag}"));
         ImGui.Text($"LastIntegrity: {GatherBuddy.AutoGather.LastIntegrity}");
         ImGui.Text($"LastCollectScore: {GatherBuddy.AutoGather.LastCollectability}");
         ImGui.Text($"IsCordialOnCooldown: {GatherBuddy.AutoGather.IsCordialOnCooldown}");

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -580,7 +580,7 @@ public partial class Interface
         if (ImGui.Button("Clear Timed Node Memory"))
         {
             GatherBuddy.Log.Information("Timed node memory cleared manually!");
-            GatherBuddy.AutoGather.TimedNodesGatheredThisTrip.Clear();
+            GatherBuddy.AutoGather.VisitedTimedLocations.Clear();
         }
 
         ImGui.Text($"Enabled: {GatherBuddy.AutoGather.Enabled}");
@@ -610,9 +610,9 @@ public partial class Interface
 
         if (ImGui.CollapsingHeader("Timed Node Memory"))
         {
-            foreach (var itemId in GatherBuddy.AutoGather.TimedNodesGatheredThisTrip)
+            foreach (var (location, time) in GatherBuddy.AutoGather.VisitedTimedLocations)
             {
-                ImGui.Text(itemId.ToString());
+                ImGui.Text($"{location.Id} {time.End}");
             }
         }
 

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -131,8 +131,8 @@ public partial class Interface
                 _weatherTable.SetDirty();
             if (ImGui.Button("Set Locations Dirty"))
                 GatherBuddy.UptimeManager.ResetLocations();
-        }
-    }
+                }
+            }
 
     private static unsafe void DrawDebugTime()
     {
@@ -613,6 +613,22 @@ public partial class Interface
             foreach (var (location, time) in GatherBuddy.AutoGather.VisitedTimedLocations)
             {
                 ImGui.Text($"{location.Id} {time.End}");
+            }
+        }
+
+        if (ImGui.CollapsingHeader("Visited nodes"))
+        {
+            foreach (var pos in GatherBuddy.AutoGather.VisitedNodes)
+            {
+                ImGui.Text($"{pos}");
+            }
+        }
+
+        if (ImGui.CollapsingHeader("Far Nodes Seen So Far"))
+        {
+            foreach (var pos in GatherBuddy.AutoGather.FarNodesSeenSoFar)
+            {
+                ImGui.Text($"{pos}");
             }
         }
 

--- a/GatherBuddy/Gui/Interface.GatherGroupTab.cs
+++ b/GatherBuddy/Gui/Interface.GatherGroupTab.cs
@@ -216,7 +216,7 @@ public partial class Interface
 
         var tt = $"{string.Join("\n", loc.Gatherables.Select(g => g.Name[GatherBuddy.Language]))}";
         if (loc is GatheringNode g)
-            tt = $"{g.Times.PrintHours()}\n{tt}";
+            tt = $"{loc.Territory.Name}\n{loc.GatheringType}\n{g.Times.PrintHours()}\n{tt}";
         ImGui.SetTooltip(tt);
     }
 

--- a/GatherBuddy/Gui/Interface.GatherWindowTab.cs
+++ b/GatherBuddy/Gui/Interface.GatherWindowTab.cs
@@ -235,15 +235,17 @@ public partial class Interface
                 _plugin.GatherWindowManager.ChangeItem(preset, GatherGroupCache.AllGatherables[newIdx], i);
             ImGui.SameLine();
             ImGui.Text("Inventory: ");
-            ImGui.SameLine();
             var invTotal = _plugin.GatherWindowManager.GetInventoryCountForItem(item);
-            ImGui.SetNextItemWidth(100f);
+            ImGui.SameLine(0f, ImGui.CalcTextSize($"0000 / ").X - ImGui.CalcTextSize($"{invTotal} / ").X);
             ImGui.Text($"{invTotal} / ");
-            ImGui.SameLine();
+            ImGui.SameLine(0, 3f);
             int quantity = (int)preset.Quantities[item.ItemId];
             ImGui.SetNextItemWidth(100f);
             if (ImGui.InputInt("##quantity", ref quantity, 1, 10))
                 _plugin.GatherWindowManager.ChangeQuantity(preset, (uint)quantity, item.ItemId);
+            ImGui.SameLine();
+            if (DrawLocationInput(item, preset.PreferredLocations.TryGetValue(item.ItemId, out var locId) ? GatherBuddy.GameData.GatheringNodes.GetValueOrDefault(locId) : null, out var newLoc))
+                _plugin.GatherWindowManager.ChangePreferredLocation(preset, item, newLoc);
             group.Dispose();
 
             _gatherWindowCache.Selector.CreateDropSource(new GatherWindowDragDropData(preset, item, i), item.Name[GatherBuddy.Language]);

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -79,7 +79,7 @@ namespace GatherBuddy.Plugin
         internal static readonly Func<Vector3, float, float, Vector3> Query_Mesh_NearestPoint;
 
         [EzIPC("vnavmesh.Query.Mesh.PointOnFloor", applyPrefix: false)]
-        internal static readonly Func<Vector3, float, float, Vector3> Query_Mesh_PointOnFloor;
+        internal static readonly Func<Vector3, bool, float, Vector3> Query_Mesh_PointOnFloor;
 
         [EzIPC("vnavmesh.Path.MoveTo", applyPrefix: false)]
         internal static readonly Action<List<Vector3>, bool> Path_MoveTo;

--- a/GatherBuddy/Plugin/UptimeManager.cs
+++ b/GatherBuddy/Plugin/UptimeManager.cs
@@ -245,6 +245,8 @@ public class UptimeManager : IDisposable
     public (ILocation? Location, TimeInterval interval) NextUptime(Gatherable item, GatheringType type, TimeStamp now,
         IReadOnlyList<ILocation>? excludes = null)
     {
+        if (item.InternalLocationId == 0)
+            return (item.Locations.FirstOrDefault(), TimeInterval.Always);
         if (item.InternalLocationId < 0)
             return (FindClosestAetheryte(item, type), TimeInterval.Always);
 


### PR DESCRIPTION
- Use luck for treasure maps. https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/192
- Don't try to overcap crystals and treasure maps. https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/182
- Don't use skills if a node doesn't have any item from the gathering list.
- Don't use Luck if hidden items are already revealed.
- Switch to the next item if the node has it and we have enough of the current one.
- Don't try to gather treasure maps if there is no map allowance.
- Abort when can't gather any items from the node.
- Abort when inventory is full.
- Extract materia before moving to the next node (like humans do).
- Dismount before waiting for GP to regenerate.
- Track visited timed nodes on a per-location basis. https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/195 https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/184 https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/147
- Solid/Age now accounts for The Giving Land buff when calculating yield. https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/196
-  Improved navigation.
- Ability to select preferred gathering location for items with multiple locations. Job preference is also taken into account.

UI:
- Show "Teleporting..." status when teleporting.
- Move consumables that exist in the inventory to the top of the list.
- Clarify skill names in the settings and fix Blessed/Bountiful typo. https://github.com/FFXIV-CombatReborn/GatherBuddyReborn/issues/114