### PR TITLE
Qol improvements

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -169,12 +169,14 @@ namespace GatherBuddy.AutoGather
         private void EnqueueActionWithDelay(Action action)
         {
             var delay = GatherBuddy.Config.AutoGatherConfig.ExecutionDelay;
-            if (delay > 0)
-            {
-                TaskManager.DelayNext((int)delay);
-            }
 
             TaskManager.Enqueue(action);
+
+            if (delay > 0)
+            {
+                TaskManager.Enqueue(() => CanAct);
+                TaskManager.DelayNext((int)delay);
+            }
         }
 
         private unsafe void DoCollectibles(int itemsLeft)

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -1,7 +1,7 @@
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using System.Linq;
-using GatherBuddy.Plugin;
+using System.Text.RegularExpressions;
 
 namespace GatherBuddy.AutoGather
 {
@@ -9,7 +9,7 @@ namespace GatherBuddy.AutoGather
     {
         private static CollectableRotation? CurrentRotation;
 
-        private unsafe class CollectableRotation
+        private unsafe partial class CollectableRotation
         {
             public CollectableRotation(uint GPToStart)
             {
@@ -18,14 +18,18 @@ namespace GatherBuddy.AutoGather
 
             private bool shouldUseFullRotation = false;
 
+            [GeneratedRegex(@"\d+")]
+            private static partial Regex NumberRegex();
+
             public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon, int itemsLeft)
             {
+                var regex = NumberRegex();
                 int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
                 int currentIntegrity = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(126)->NodeText.ToString());
                 int maxIntegrity     = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(129)->NodeText.ToString());
-                int scourColl        = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString().Substring(2));
-                int meticulousColl   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString().Substring(2));
-                int brazenColl       = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(93)->NodeText.ToString().Substring(2));
+                int scourColl        = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString()).Value);
+                int meticulousColl   = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString()).Value);
+                int brazenColl       = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(93)->NodeText.ToString()).Value);
 
                 if (ShouldUseWise(currentIntegrity, maxIntegrity))
                     return Actions.Wise;

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -84,7 +84,7 @@ namespace GatherBuddy.AutoGather
                 //Join node slots, retaing list order
                 .Join(aviable, i => i.Item, s => s.Item, (i, s) => (Slot: s, i.Quantity))
                 //And we need more of them
-                .Where(x => x.Quantity < QuantityTotal(x.Slot.Item))
+                .Where(x => InventoryCount(x.Slot.Item) < x.Quantity)
                 .Select(x => x.Slot);
 
             var fallbackSkills = GatherBuddy.Config.AutoGatherConfig.UseSkillsForFallbackItems;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -388,7 +388,7 @@ namespace GatherBuddy.AutoGather
                 foreach (var node in visibleNodes.Where(o => o.Position.DistanceToPlayer() < 80))
                     FarNodesSeenSoFar.Add(node.Position);
 
-                if (FarNodesSeenSoFar.Contains(CurrentDestination))
+                if (CurrentDestination.DistanceToPlayer() < 80)
                 {
                     GatherBuddy.Log.Verbose("Far node is not targetable, choosing another");
                 }
@@ -405,7 +405,7 @@ namespace GatherBuddy.AutoGather
             {
                 var pos = TimedNodePosition;
                 // marker not yet loaded on game
-                if (pos == null)
+                if (pos == null || targetInfo.Time.Start > GatherBuddy.Time.ServerTime.AddSeconds(5))
                 {
                     AutoStatus = "Waiting on flag show up";
                     return;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -216,6 +216,10 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
+            foreach (var (loc, time) in VisitedTimedLocations)
+                if (time.End < AdjuctedServerTime)
+                    VisitedTimedLocations.Remove(loc);
+
             {//Block to limit the scope of the variable "next"
                 UpdateItemsToGather();
                 var next = ItemsToGather.FirstOrDefault();
@@ -234,10 +238,6 @@ namespace GatherBuddy.AutoGather
                     AutoStatus = "No available items to gather";
                     return;
                 }
-
-                foreach (var (loc, time) in VisitedTimedLocations)
-                    if (time.End < AdjuctedServerTime)
-                        VisitedTimedLocations.Remove(loc);
 
                 if (targetInfo == null
                     || targetInfo.Location == null


### PR DESCRIPTION
Bugfixes:
- Fix collectable abilities are used incorrectly in the Japanese client.
- Fix fallback presets are not working.
- Fix navigating to a flag of a completely different node when precognition is high and two timed nodes are spawned in the current location in succession.
- Fix GBR stuck in the idle state when there is only one timed item in the list.

Changes:
- Apply execution delay after executing an action, not before. This should prevent incorrect skill usage when ping is high.