### PR TITLE
Bump DalamudApiLevel to 11

### DIFF
--- a/GatherBuddy/GatherBuddyReborn.yaml
+++ b/GatherBuddy/GatherBuddyReborn.yaml
@@ -5,8 +5,8 @@ description: |-
   via item name and a UI to keep track of special uptime and weather conditions.
 punchline: Simplify Gathering and Fishing.
 repo_url: https://github.com/FFXIV-CombatReborn/GatherBuddyReborn
-DalamudApiLevel: 10
-TestingDalamudApiLevel: 10
+DalamudApiLevel: 11
+TestingDalamudApiLevel: 11
 tags:
   - Gathering
   - Fishing


### PR DESCRIPTION
Bumps the `DalamudApiLevel` to 11 in the GatherBuddyReborn.yaml. 

Most likely doesn't matter with how the plugin is built by github actions, but probably best to still do