### PR TITLE
Workaround for race condition in vnavmesh IPC

### DIFF
--- a/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
+++ b/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
@@ -19,6 +19,7 @@ namespace GatherBuddy.AutoGather.Movement
         private DateTime _unstuckStart;
         private DateTime _lastCheck;
         private Vector3 _lastPosition;
+        private bool _lastWasFailure;
 
         public bool IsRunning => _movementController.Enabled;
 
@@ -45,7 +46,7 @@ namespace GatherBuddy.AutoGather.Movement
                     {
                         _lastPosition = Player.Position;
                         _lastMovement = now;
-                    } 
+                    }
                     else if (isPathing)
                     {
                         if (_lastPosition.DistanceToPlayer() >= MinMovementDistance)
@@ -59,9 +60,9 @@ namespace GatherBuddy.AutoGather.Movement
                             // If the character hasn't moved much
                             GatherBuddy.Log.Debug($"Advanced Unstuck: stuck detected. Moved {_lastPosition.DistanceToPlayer()} yalms in {now.Subtract(_lastMovement).TotalSeconds} seconds.");
                             Start(false);
-                        }                        
+                        }
                     }
-                    else
+                    else if (_lastWasFailure)
                     {
                         //vnavmesh failed to find a path
                         GatherBuddy.Log.Debug($"Advanced Unstuck: vnavmesh failure detected.");
@@ -69,6 +70,7 @@ namespace GatherBuddy.AutoGather.Movement
                     }
                 }
             }
+            _lastWasFailure = !isPathGenerating && !isPathing;
             return IsRunning;
         }
 


### PR DESCRIPTION
Path_IsRunning() and Nav_PathfindInProgress() may both return false in the moment right after pathfinding is completed. Advanced Unstuck treats this condition as vnavmesh failure. Avoid unnecessary activation of Advanced Unstuck by treating this condition as failure only if it persists for two framework updates.