### PR TITLE
Workaround for race condition in vnavmesh IPC

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -63,6 +63,9 @@ namespace GatherBuddy.AutoGather
 
         public bool ShouldFly(Vector3 destination)
         {
+            if (Dalamud.Conditions[ConditionFlag.InFlight] || Dalamud.Conditions[ConditionFlag.Diving])
+                return true;
+
             if (GatherBuddy.Config.AutoGatherConfig.ForceWalking || Dalamud.ClientState.LocalPlayer == null)
             {
                 return false;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -185,11 +185,16 @@ namespace GatherBuddy.AutoGather
             var isPathGenerating = IsPathGenerating;
             var isPathing = IsPathing;
 
-            if (_advancedUnstuck.IsRunning || CurrentDestination != default && CurrentDestination.DistanceToPlayer() > 3 && _advancedUnstuck.Check(isPathGenerating, isPathing))
+            switch (_advancedUnstuck.Check(CurrentDestination, isPathGenerating, isPathing))
             {
-                StopNavigation();
-                AutoStatus = $"Advanced unstuck in progress!";
-                return;
+                case AdvancedUnstuckCheckResult.Pass:
+                    break;
+                case AdvancedUnstuckCheckResult.Wait:
+                    return;
+                case AdvancedUnstuckCheckResult.Fail:
+                    StopNavigation();
+                    AutoStatus = $"Advanced unstuck in progress!";
+                    return;
             }
 
             if (isPathGenerating)


### PR DESCRIPTION
Path_IsRunning() and Nav_PathfindInProgress() may both return false in the moment right after pathfinding is completed. Advanced Unstuck treats this condition as vnavmesh failure. Avoid unnecessary activation of Advanced Unstuck by treating this condition as failure only if it persists for two framework updates.