### PR TITLE
Bugfixes

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -265,7 +265,7 @@ namespace GatherBuddy.AutoGather
                 return false;
             if (action.EffectType is Actions.EffectType.CrystalsYield && !item.IsCrystal)
                 return false;
-            if (action.EffectType is Actions.EffectType.Integrity && NodeTracker.Integrity == NodeTracker.MaxIntegrity)
+            if (action.EffectType is Actions.EffectType.Integrity && NodeTracker.Integrity > Math.Min(2, NodeTracker.MaxIntegrity - 1))
                 return false;
             if (action.EffectType is not Actions.EffectType.Other and not Actions.EffectType.GatherChance && rare)
                 return false;

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -166,16 +166,26 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        private void EnqueueActionWithDelay(Action action)
+        private void EnqueueActionWithDelay(Action action, bool immediate = false)
         {
             var delay = GatherBuddy.Config.AutoGatherConfig.ExecutionDelay;
-
-            TaskManager.Enqueue(action);
+            if (immediate)
+                TaskManager.EnqueueImmediate(action);
+            else
+                TaskManager.Enqueue(action);
 
             if (delay > 0)
             {
-                TaskManager.Enqueue(() => CanAct);
-                TaskManager.DelayNext((int)delay);
+                if (immediate)
+                {
+                    TaskManager.EnqueueImmediate(() => CanAct);
+                    TaskManager.DelayNextImmediate((int)delay);
+                }
+                else
+                {
+                    TaskManager.Enqueue(() => CanAct);
+                    TaskManager.DelayNext((int)delay);
+                }
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -1,5 +1,6 @@
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.UI;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -144,7 +145,7 @@ namespace GatherBuddy.AutoGather
 
             private static bool ShouldSolidAgeCollectables(int integrity, int maxIntegrity, int itemsLeft)
             {
-                if (integrity == maxIntegrity)
+                if (integrity > Math.Min(2, maxIntegrity - 1))
                     return false;
                 if (itemsLeft <= integrity)
                     return false;

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -83,11 +83,15 @@ namespace GatherBuddy.AutoGather
                         //If early dismount failed, navigate to the nearest floor point
                         if (Dalamud.Conditions[ConditionFlag.Mounted] && Dalamud.Conditions[ConditionFlag.InFlight] && !Dalamud.Conditions[ConditionFlag.Diving])
                         {
-                            var floor = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(Player.Position, false, 3);
-                            Navigate(floor, true);
-                            TaskManager.Enqueue(() => !IsPathGenerating);
-                            TaskManager.Enqueue(() => !IsPathing, 1000);
-                            EnqueueDismount();
+                            try
+                            {
+                                var floor = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(Player.Position, false, 3);
+                                Navigate(floor, true);
+                                TaskManager.Enqueue(() => !IsPathGenerating);
+                                TaskManager.Enqueue(() => !IsPathing, 1000);
+                                EnqueueDismount();
+                            }
+                            catch { }
                             //If even that fails, do advanced unstuck
                             TaskManager.Enqueue(() => { if (Dalamud.Conditions[ConditionFlag.Mounted]) _advancedUnstuck.Force(); });
                         }

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -481,7 +481,7 @@ namespace GatherBuddy.AutoGather
                         return true;
                     }
 
-                    return IsGathering;       
+                    return !IsGathering;       
                 });
             }
         }


### PR DESCRIPTION
- Fix wait condition in CloseGatheringAddons().
- ~~Print an error and disable Auto-gather when the client is in an erroneous state.~~ Excluded due to encountered false positives
- Use Solid Reason / Ageless Words at 2 integrity. This is to compensate for possible lag, when client state is not updated before the client is ready to use the next action.
-  Fix Lifestream is called before closing a node when the inventory is full.
- Fix unhandled vnavmesh exception in the fallback dismount routine.