### PR TITLE
Experimental fix for lingering GatheringMasterpiece addon

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -1,10 +1,8 @@
-﻿using ECommons.DalamudServices;
-using ECommons.GameHelpers;
+﻿using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using GatherBuddy.Classes;
 using System;
 using System.Linq;
-using Dalamud.Game.ClientState.Conditions;
 using ItemSlot = GatherBuddy.AutoGather.GatheringTracker.ItemSlot;
 using GatherBuddy.CustomInfo;
 using System.Collections.Generic;

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -68,6 +68,7 @@ namespace GatherBuddy.AutoGather
         public bool UseSkillsForFallbackItems { get; set; } = false;
         public bool AbandonNodes { get; set; } = false;
         public uint ExecutionDelay { get; set; } = 0;
+        public bool ForceCloseLingeringMasterpieceAddon { get; set; } = false;
 
         public enum SortingType
         {

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -133,6 +133,9 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
+            if (CheckForLingeringMasterpieceAddon())
+                return;
+
             if (FreeInventorySlots == 0)
             {
                 AbortAutoGather("Inventory is full");
@@ -561,6 +564,53 @@ namespace GatherBuddy.AutoGather
             Chat.Instance.ExecuteCommand($"/gearset change \"{set}\"");
             TaskManager.DelayNext(Random.Shared.Next(500, 1500));  //Add a random delay to be less suspicious 
             return true;
+        }
+
+        private bool CheckForLingeringMasterpieceAddon()
+        {
+            if (IsMasterpieceOK())
+                return false;
+
+            GatherBuddy.Log.Warning("Lingering GatheringMasterpiece addon may have been detected, rechecking in one second.");
+
+            //Check again in a second to reduce the probability of false positives due to lags or race conditions.
+            TaskManager.DelayNext(1000);
+            TaskManager.Enqueue(() =>
+            {
+                if (IsMasterpieceOK())
+                    return;
+
+                GatherBuddy.Log.Error("Lingering GatheringMasterpiece addon detected.");
+                Communicator.PrintError("Your game client is in an erroneous state: the GatheringMasterpiece addon (collectable window) is left lingering in the memory " +
+                    "after the end of the gathering session. This may be due to a bug in some plugin, Dalamud, or the game itself. Gathering a collectable will crash your game. " +
+                    "You may need to restart it.");
+                if (GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon)
+                {
+                    Communicator.PrintError("Attempting to force close GatheringMasterpiece addon.");
+                    GatherBuddy.Log.Warning("Attempting to force close GatheringMasterpiece addon.");
+                    unsafe { MasterpieceAddon->Close(true); }
+                    TaskManager.DelayNext(1000);//It persists for a few framework updates, so we wait.
+                }
+                else
+                {
+                    Communicator.PrintError("Alternatively, you can try enabling the \"Force close lingering GatheringMasterpiece addon\" option under Auto-Gather > Advanced.");
+                    Enabled = false;
+                    AutoStatus = "Error";
+                }
+            });
+            return true;
+
+            unsafe bool IsMasterpieceOK()
+            {
+                if (MasterpieceAddon == null)
+                    return true;
+
+                var gathering = GatheringAddon;
+                if (IsGathering && (gathering == null || !gathering->IsVisible))
+                    return true;
+
+                return false;
+            }
         }
 
         public void Dispose()

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -192,6 +192,12 @@ public partial class Interface
 
             ImGuiUtil.HoverTooltip("Delay executing each action by the specified amount.");
         }
+        public static void DrawForceCloseLingeringMasterpieceAddon()
+            => DrawCheckbox(
+                "Force close lingering GatheringMasterpiece addon (DANGEROUS, MAY CRASH THE GAME)",
+                "Attempt to forcefully close the GatheringMasterpiece addon if it is left lingering in the game memory after the end of the gathering session due to a bug",
+                GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon,
+                b => GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon = b);
 
         public static void DrawBYIIBox()
             => DrawCheckbox("Use Bountiful Yield/Harvest", "Toggle whether to use Bountiful Yield/Harvest for gathering.", GatherBuddy.Config.AutoGatherConfig.BYIIConfig.UseAction,
@@ -1385,6 +1391,7 @@ public partial class Interface
                 ConfigFunctions.DrawForceWalkingBox();
                 ConfigFunctions.DrawAdvancedUnstuckBox();
                 ConfigFunctions.DrawMaterialExtraction();
+                ConfigFunctions.DrawForceCloseLingeringMasterpieceAddon();
                 ConfigFunctions.DrawAntiStuckCooldown();
                 ConfigFunctions.DrawStuckThreshold();
                 ConfigFunctions.DrawTimedNodePrecog();


### PR DESCRIPTION
GBR may sometimes be stuck with an open gathering window when gathering collectables. If the player clicks the collectable manually, the game crashes. This happens because sometimes after gathering collectables in a node, the GatheringMasterpiece addon would not close and continue to linger in the memory but invisible. What causes this is unknown.
This patch will detect the erroneous condition and stop Auto-Gather or, if the corresponding option is enabled, attempt to Close() the addon.
While testing, I've reproduced the issue thrice. The first time, after closing the addon, the issue repeated again and again until the game was restarted. The second and third time, the issue disappeared after the first Close().
