### PR TITLE
Proposal: remove the option to disable advanced unstuck

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -53,7 +53,6 @@ namespace GatherBuddy.AutoGather
         public uint MinimumCollectibilityScore { get; set; } = 1000;
         public bool GatherIfLastIntegrity { get; set; } = false;
         public uint GatherIfLastIntegrityMinimumCollectibility { get; set; } = 600;
-        public bool UseExperimentalUnstuck { get; set; } = true;
         public ConsumableConfig CordialConfig { get; set; } = new(false, 0, 700, 0);
         public ConsumableConfig FoodConfig { get; set; } = new(false, 0, 0, 0);
         public ConsumableConfig PotionConfig { get; set; } = new(false, 0, 0, 0);

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -145,38 +145,6 @@ namespace GatherBuddy.AutoGather
         private DateTime lastMovementTime;
         private DateTime lastResetTime;
 
-
-        private void StuckCheck()
-        {
-            if (GatherBuddy.Config.AutoGatherConfig.UseExperimentalUnstuck)
-                return;
-            
-            if (EzThrottler.Throttle("StuckCheck", 100))
-            {
-                // Check if character is stuck
-                if (lastPosition.HasValue && Vector3.Distance(Player.Object.Position, lastPosition.Value) < 2.0f)
-                {
-                    // If the character hasn't moved much
-                    if ((DateTime.Now - lastMovementTime).TotalSeconds > GatherBuddy.Config.AutoGatherConfig.NavResetThreshold)
-                    {
-                        // Check if enough time has passed since the last reset
-                        if ((DateTime.Now - lastResetTime).TotalSeconds > GatherBuddy.Config.AutoGatherConfig.NavResetCooldown)
-                        {
-                            GatherBuddy.Log.Warning("Character is stuck, resetting navigation...");
-                            StopNavigation();
-                            return;
-                        }
-                    }
-                }
-                else
-                {
-                    // Character has moved, update last known position and time
-                    lastPosition     = Player.Object.Position;
-                    lastMovementTime = DateTime.Now;
-                }
-            }
-        }
-
         private void StopNavigation()
         {
             // Reset navigation logic here

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -207,11 +207,6 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (isPathing)
-            {
-                StuckCheck();
-            }
-
             if (GatherBuddy.Config.AutoGatherConfig.DoMaterialize 
                 && Player.Job is Job.BTN or Job.MIN
                 && !isPathing 

--- a/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
+++ b/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
@@ -34,9 +34,6 @@ namespace GatherBuddy.AutoGather.Movement
             if (IsRunning)
                 return AdvancedUnstuckCheckResult.Fail;
 
-            if (!GatherBuddy.Config.AutoGatherConfig.UseExperimentalUnstuck)
-                return AdvancedUnstuckCheckResult.Pass;
-
             var now = DateTime.Now;
 
             //On cooldown, not navigating or near the destination: disable tracking and reset

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -75,12 +75,6 @@ public partial class Interface
                 "or if the node didn't have any needed items on the first place.",
                 GatherBuddy.Config.AutoGatherConfig.AbandonNodes, b => GatherBuddy.Config.AutoGatherConfig.AbandonNodes = b);
 
-        public static void DrawAdvancedUnstuckBox()
-            => DrawCheckbox("Enable Experimental Unstuck Method",
-                "Use super special movement techniques to manually move your character without navmesh when stuck",
-                GatherBuddy.Config.AutoGatherConfig.UseExperimentalUnstuck,
-                b => GatherBuddy.Config.AutoGatherConfig.UseExperimentalUnstuck = b);
-
         public static void DrawHonkModeBox()
             => DrawCheckbox("Play a sound when done gathering", "Play a sound when auto-gathering shuts down because your list is complete",
                 GatherBuddy.Config.AutoGatherConfig.HonkMode,   b => GatherBuddy.Config.AutoGatherConfig.HonkMode = b);
@@ -1389,7 +1383,6 @@ public partial class Interface
                 ConfigFunctions.DrawAutoGatherBox();
                 ConfigFunctions.DrawUseFlagBox();
                 ConfigFunctions.DrawForceWalkingBox();
-                ConfigFunctions.DrawAdvancedUnstuckBox();
                 ConfigFunctions.DrawMaterialExtraction();
                 ConfigFunctions.DrawForceCloseLingeringMasterpieceAddon();
                 ConfigFunctions.DrawAntiStuckCooldown();


### PR DESCRIPTION
Navigation is pretty much unusable without it, and many reported issues with navigation were actually due to advanced unstuck being disabled.