### PR TITLE
Fixes

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -200,18 +200,19 @@ namespace GatherBuddy.AutoGather
             else
                 TaskManager.Enqueue(action);
 
-            if (delay > 0)
+            //Always delay the next action by at least 1 tick (2 or 3 in fact in the current implementation).
+            //There is a possibility that client state update is happening the same tick when CanAct becomes true, and GBR won't see it if executed before it is done.
+            //Since GBR Update() may be called in the same tick after TaskManager gets CanAct == true (depending on call order in the Update event),
+            //we must always add a delay, which adds 2 extra ticks.
+            if (immediate)
             {
-                if (immediate)
-                {
-                    TaskManager.EnqueueImmediate(() => CanAct);
-                    TaskManager.DelayNextImmediate((int)delay);
-                }
-                else
-                {
-                    TaskManager.Enqueue(() => CanAct);
-                    TaskManager.DelayNext((int)delay);
-                }
+                TaskManager.EnqueueImmediate(() => CanAct);
+                TaskManager.DelayNextImmediate((int)delay);
+            }
+            else
+            {
+                TaskManager.Enqueue(() => CanAct);
+                TaskManager.DelayNext((int)delay);
             }
         }
 

--- a/GatherBuddy/AutoGather/ConfigPreset.cs
+++ b/GatherBuddy/AutoGather/ConfigPreset.cs
@@ -191,7 +191,8 @@ namespace GatherBuddy.AutoGather
         }
 
         public bool Match(Gatherable item) =>
-            (
+            Enabled
+            && (
                 !ItemLevel.UseGlv && item.Level >= ItemLevel.Min && item.Level <= ItemLevel.Max
               || ItemLevel.UseGlv && item.GatheringData.GatheringItemLevel.RowId >= ItemLevel.Min && item.GatheringData.GatheringItemLevel.RowId <= ItemLevel.Max
             )

--- a/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
@@ -290,8 +290,10 @@ namespace GatherBuddy.Gui
                 }
                 ImGui.SameLine();
                 if (ImGui.RadioButton("level", !useGlv)) useGlv = false;
+                ImGuiUtil.HoverTooltip("Level as shown in the gathering log and the gathering window.");
                 ImGui.SameLine();
                 if (ImGui.RadioButton("glv", useGlv)) useGlv = true;
+                ImGuiUtil.HoverTooltip("Gathering level (hidden stat). Use it to distinguish between different tiers of legendary nodes.");
                 if (useGlv != preset.ItemLevel.UseGlv)
                 {
                     int min, max;

--- a/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
@@ -509,7 +509,7 @@ namespace GatherBuddy.Gui
             if (action is ConfigPreset.ActionConfigIntegrity action4)
             {
                 var tmp = action4.MinIntegrity;
-                if (ImGui.DragInt("Total node integrity required", ref tmp, 0.1f, 1, ConfigPreset.MaxIntegrity))
+                if (ImGui.DragInt("Minumum initial node integrity", ref tmp, 0.1f, 1, ConfigPreset.MaxIntegrity))
                     action4.MinIntegrity = tmp;
                 if (ImGui.IsItemDeactivatedAfterEdit())
                     save();


### PR DESCRIPTION
- Add at least 1 tick delay before executing a next action. This was default behavior before introducing the configurable execution delay. There were reports after the change that Solid / Ageless / Wise were executed out of order, and I was able to reproduce it once with a 37 ms ping. I suspect that without an extra delay, the client's state update may be happening during the very same tick, and depending on execution order or even a race condition, GBR may execute the next action before the state is updated.
- Change the wording of the "Total node integrity required" option, as suggested in Discord.
- Add tooltip for item level and glv.
- Respect Enabled setting of a preset