### PR TITLE
Add configuration option to hide completed items from the gather window.

### DIFF
--- a/GatherBuddy/Config/Configuration.cs
+++ b/GatherBuddy/Config/Configuration.cs
@@ -107,6 +107,7 @@ public partial class Configuration : IPluginConfiguration
     public bool             ShowGatherWindowAlarms         { get; set; } = true;
     public bool             SortGatherWindowByUptime       { get; set; } = false;
     public bool             ShowGatherWindowOnlyAvailable  { get; set; } = false;
+    public bool             HideGatherWindowCompletedItems { get; set; } = false;
     public bool             HideGatherWindowInDuty         { get; set; } = true;
     public bool             OnlyShowGatherWindowHoldingKey { get; set; } = false;
     public bool             LockGatherWindow               { get; set; } = false;

--- a/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
+++ b/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
@@ -117,6 +117,12 @@ public class GatherWindow : Window
         if (GatherBuddy.Config.ShowGatherWindowOnlyAvailable && time.Start > GatherBuddy.Time.ServerTime)
             return;
 
+        var inventoryCount = _plugin.AutoGatherListsManager.GetInventoryCountForItem(item);
+        var quantity = _plugin.AutoGatherListsManager.GetTotalQuantitiesForItem(item);
+
+        if (quantity > 0 && inventoryCount >= quantity && GatherBuddy.Config.HideGatherWindowCompletedItems)
+            return;
+
         if (ImGui.TableNextColumn())
         {
             using var style = ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemSpacing / 2);
@@ -128,8 +134,6 @@ public class GatherWindow : Window
             var colorId = time == TimeInterval.Always    ? ColorId.GatherWindowText :
                 time.Start > GatherBuddy.Time.ServerTime ? ColorId.GatherWindowUpcoming : ColorId.GatherWindowAvailable;
 
-            var inventoryCount                      = _plugin.AutoGatherListsManager.GetInventoryCountForItem(item);
-            var quantity                            = _plugin.AutoGatherListsManager.GetTotalQuantitiesForItem(item);
             if (quantity > 0 && inventoryCount >= quantity)
                 colorId = ColorId.DisabledText;
             using var color                         = ImRaii.PushColor(ImGuiCol.Text, colorId.Value());

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -564,6 +564,11 @@ public partial class Interface
                 "Show only those items from your gather window setup that are currently available.",
                 GatherBuddy.Config.ShowGatherWindowOnlyAvailable, b => GatherBuddy.Config.ShowGatherWindowOnlyAvailable = b);
 
+        public static void DrawHideGatherWindowCompletedItemsBox()
+            => DrawCheckbox("Hide Completed Items",
+                "Hide items that have the required inventory amount present in inventory.",
+                GatherBuddy.Config.HideGatherWindowCompletedItems, b => GatherBuddy.Config.HideGatherWindowCompletedItems = b);
+
         public static void DrawHideGatherWindowInDutyBox()
             => DrawCheckbox("Hide Gather Window in Duty",
                 "Hide the gather window when bound by any duty.",
@@ -784,6 +789,7 @@ public partial class Interface
                 ConfigFunctions.DrawGatherWindowAlarmsBox();
                 ConfigFunctions.DrawSortGatherWindowBox();
                 ConfigFunctions.DrawGatherWindowShowOnlyAvailableBox();
+                ConfigFunctions.DrawHideGatherWindowCompletedItemsBox();
                 ConfigFunctions.DrawHideGatherWindowInDutyBox();
                 ConfigFunctions.DrawGatherWindowHoldKey();
                 ConfigFunctions.DrawGatherWindowLockBox();


### PR DESCRIPTION
I tend to have large auto gather lists that take up the entire side of my screen, so I was motivated to add a configuration option similar to the one in Teamcraft's List View to hide completed items, as there is already logic present to color completed items with a grey color.