### PR TITLE
Fixes and QoL improvements

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.ActionIDs.cs
+++ b/GatherBuddy/AutoGather/AutoGather.ActionIDs.cs
@@ -52,6 +52,7 @@ public partial class AutoGather
 
             public Pair<Action> Actions => actions;
             public Pair<string> Names => names;
+            public Pair<uint> QuestIds => (actions.Botanist.UnlockLink.RowId, actions.Miner.UnlockLink.RowId);
             public uint ActionId => GetJobValue(actions).RowId;
             public uint QuestId  => GetJobValue(actions).UnlockLink.RowId;
             public uint EffectId => GetJobValue(effects);

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -8,6 +8,7 @@ using GatherBuddy.CustomInfo;
 using System.Collections.Generic;
 using GatherBuddy.AutoGather.Helpers;
 using GatherBuddy.AutoGather.Extensions;
+using GatherBuddy.AutoGather.Lists;
 
 namespace GatherBuddy.AutoGather
 {
@@ -99,40 +100,40 @@ namespace GatherBuddy.AutoGather
         }
 
 
-        private unsafe void DoActionTasks(Gatherable? desiredItem)
+        private unsafe void DoActionTasks(GatherTarget target)
         {
             if (MasterpieceAddon != null)
             {
                 var left = int.MaxValue;
                 if (GatherBuddy.Config.AutoGatherConfig.AbandonNodes)
                 { 
-                    if (desiredItem == null) throw new NoGatherableItemsInNodeException();
-                    left = (int)QuantityTotal(desiredItem) - desiredItem.GetInventoryCount();
+                    if (target == default) throw new NoGatherableItemsInNodeException();
+                    left = (int)target.Quantity - target.Item.GetInventoryCount();
                     if (left < 1) throw new NoGatherableItemsInNodeException();
                 }
 
-                DoCollectibles(MatchConfigPreset(desiredItem), left);
+                DoCollectibles(MatchConfigPreset(target.Item), left);
             }
             else if (GatheringAddon != null && NodeTracker.Ready)
             {
-                DoGatherWindowActions(desiredItem);
+                DoGatherWindowActions(target);
             }
             if (MasterpieceAddon == null)
                 CurrentRotation = null;
         }
 
-        private unsafe void DoGatherWindowActions(Gatherable? desiredItem)
+        private unsafe void DoGatherWindowActions(GatherTarget target)
         {
             if (LuckUsed[1] && !LuckUsed[2] && NodeTracker.Revisit) LuckUsed = new(0);
 
             //Use The Giving Land out of order to gather random crystals.
-            if (ShouldUseGivingLandOutOfOrder(desiredItem))
+            if (ShouldUseGivingLandOutOfOrder(target.Item))
             {
                 EnqueueActionWithDelay(() => UseAction(Actions.GivingLand));
                 return;
             }
 
-            if (!HasGivingLandBuff && ShouldUseLuck(desiredItem))
+            if (!HasGivingLandBuff && ShouldUseLuck(target.Item))
             {
                 LuckUsed[1] = true;
                 LuckUsed[2] = NodeTracker.Revisit;
@@ -140,7 +141,7 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            var (useSkills, slot) = GetItemSlotToGather(desiredItem);
+            var (useSkills, slot) = GetItemSlotToGather(target);
             if (useSkills)
             {
                 var configPreset = MatchConfigPreset(slot.Item);

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -7,6 +7,7 @@ using ItemSlot = GatherBuddy.AutoGather.GatheringTracker.ItemSlot;
 using GatherBuddy.CustomInfo;
 using System.Collections.Generic;
 using GatherBuddy.AutoGather.Helpers;
+using GatherBuddy.AutoGather.Extensions;
 
 namespace GatherBuddy.AutoGather
 {
@@ -57,7 +58,7 @@ namespace GatherBuddy.AutoGather
                 return false;
             if (!IsGivingLandOffCooldown)
                 return false;
-            if (InventoryCount(slot.Item) > 9999 - GivingLandYield - slot.Yield)
+            if (slot.Item.GetInventoryCount() > 9999 - GivingLandYield - slot.Yield)
                 return false;
 
             return true;
@@ -67,7 +68,7 @@ namespace GatherBuddy.AutoGather
         {
             if (!CheckConditions(Actions.TwelvesBounty, config.TwelvesBounty, slot.Item, slot))
                 return false;
-            if (InventoryCount(slot.Item) > 9999 - 3 - slot.Yield - (slot.RandomYield ? GivingLandYield : 0))
+            if (slot.Item.GetInventoryCount() > 9999 - 3 - slot.Yield - (slot.RandomYield ? GivingLandYield : 0))
                 return false;
 
             return true;
@@ -106,7 +107,7 @@ namespace GatherBuddy.AutoGather
                 if (GatherBuddy.Config.AutoGatherConfig.AbandonNodes)
                 { 
                     if (desiredItem == null) throw new NoGatherableItemsInNodeException();
-                    left = (int)QuantityTotal(desiredItem) - InventoryCount(desiredItem);
+                    left = (int)QuantityTotal(desiredItem) - desiredItem.GetInventoryCount();
                     if (left < 1) throw new NoGatherableItemsInNodeException();
                 }
 

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -373,7 +373,7 @@ namespace GatherBuddy.AutoGather
             {
                 var glvl = item.GatheringData.GatheringItemLevel.RowId;
                 var baseValue = WorldData.IlvConvertTable[(int)glvl].BaseGathering;
-                var stat = CharacterGatheringStat;
+                var stat = DiscipleOfLand.Gathering;
 
                 if (stat >= baseValue * 11 / 10)
                     return 3;

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -1,5 +1,7 @@
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.UI;
+using GatherBuddy.AutoGather.Extensions;
+using GatherBuddy.Classes;
 using System;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -8,23 +10,27 @@ namespace GatherBuddy.AutoGather
 {
     public partial class AutoGather
     {
-        private CollectableRotation? CurrentRotation;
+        private CollectableRotation? CurrentCollectableRotation;
 
         private unsafe partial class CollectableRotation
         {
-            public CollectableRotation(ConfigPreset config)
+            public CollectableRotation(ConfigPreset config, Gatherable item, uint quantity)
             {
                 this.config = config;
                 shouldUseFullRotation = Player.Object.CurrentGp >= config.CollectableActionsMinGP;
+                this.item = item;
+                this.quantity = quantity;
             }
 
-            private bool shouldUseFullRotation = false;
+            private readonly bool shouldUseFullRotation = false;
             private readonly ConfigPreset config;
+            private readonly Gatherable item;
+            private readonly uint quantity;
 
             [GeneratedRegex(@"\d+")]
             private static partial Regex NumberRegex();
 
-            public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon, int itemsLeft)
+            public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
             {
                 var regex = NumberRegex();
                 int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
@@ -33,6 +39,7 @@ namespace GatherBuddy.AutoGather
                 int scourColl        = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(84)->NodeText.ToString()).Value);
                 int meticulousColl   = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(108)->NodeText.ToString()).Value);
                 int brazenColl       = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(93)->NodeText.ToString()).Value);
+                int itemsLeft        = (int)(quantity - item.GetInventoryCount());
 
                 if (ShouldUseWise(currentIntegrity, maxIntegrity))
                     return Actions.Wise;

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -32,6 +32,11 @@ namespace GatherBuddy.AutoGather
 
             public Actions.BaseAction GetNextAction(AddonGatheringMasterpiece* MasterpieceAddon)
             {
+                var itemsLeft = (int)(quantity - item.GetInventoryCount());
+
+                if (itemsLeft <= 0 && GatherBuddy.Config.AutoGatherConfig.AbandonNodes)
+                    throw new NoGatherableItemsInNodeException();
+
                 var regex = NumberRegex();
                 var tNode = MasterpieceAddon->AtkUnitBase.GetNodeById(15)->IsVisible() ? 15u : 14u;
                 int collectability   = int.Parse(MasterpieceAddon->AtkUnitBase.GetTextNodeById(6)->NodeText.ToString());
@@ -42,9 +47,8 @@ namespace GatherBuddy.AutoGather
                 int brazenColl       = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetTextNodeById(93)->NodeText.ToString()).Value);
                 int targetScore      = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetComponentByNodeId(tNode)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText.ToString()).Value);
                 int minScore         = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetComponentByNodeId(13)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText.ToString()).Value);
-                int itemsLeft        = (int)(quantity - item.GetInventoryCount());
 
-                // For custom deliveries and quest items we always want max collectability
+                // For custom deliveries and quest items, we always want max collectability
                 if (item.GatheringData.Unknown3 is 3 or 4 or 6)
                     minScore = targetScore;
 

--- a/GatherBuddy/AutoGather/AutoGather.Collectables.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Collectables.cs
@@ -44,6 +44,10 @@ namespace GatherBuddy.AutoGather
                 int minScore         = int.Parse(regex.Match(MasterpieceAddon->AtkUnitBase.GetComponentByNodeId(13)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText.ToString()).Value);
                 int itemsLeft        = (int)(quantity - item.GetInventoryCount());
 
+                // For custom deliveries and quest items we always want max collectability
+                if (item.GatheringData.Unknown3 is 3 or 4 or 6)
+                    minScore = targetScore;
+
                 if (config.CollectableManualScores)
                     (targetScore, minScore) = (config.CollectableTagetScore, config.CollectableMinScore);
 

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -67,7 +67,6 @@ namespace GatherBuddy.AutoGather
         public bool UseSkillsForFallbackItems { get; set; } = false;
         public bool AbandonNodes { get; set; } = false;
         public uint ExecutionDelay { get; set; } = 0;
-        public bool ForceCloseLingeringMasterpieceAddon { get; set; } = false;
         public bool ConfigConversionFixed { get; set; } = false;
         public bool RotationSolverConversionDone { get; set; } = false;
 

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -60,6 +60,7 @@ namespace GatherBuddy.AutoGather
         [Obsolete] public ConsumableConfig SquadronManualConfig { get; set; } = new(false, 0, 0, 0);
         [Obsolete] public ConsumableConfig SquadronPassConfig { get; set; } = new(false, 0, 0, 0);
         public bool DoMaterialize { get; set; } = false;
+        public bool DoReduce { get; set; } = false;
         public bool HonkMode { get; set; } = true;
         public SortingType SortingMethod { get; set; } = SortingType.Location;
         public bool GoHomeWhenIdle { get; set; } = true;

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -157,9 +157,11 @@ namespace GatherBuddy.AutoGather
                 .Where(s => s.Item.IsCrystal)
                 .Where(CheckItemOvercap)
                 //Prioritize crystals in the gathering list
-                .OrderBy(s => _activeItemList.Contains(s.Item) ? 0 : 1)
+                .GroupJoin(_activeItemList.Where(i => i.Item.IsCrystal), s => s.Item, i => i.Item, (s, x) => (Slot: s, Order: x.Any()?1:0))
+                .OrderBy(x => x.Order)
                 //Prioritize crystals with a lower amount in the inventory
-                .ThenBy(s => s.Item.GetInventoryCount())
+                .ThenBy(x => x.Slot.Item.GetInventoryCount())
+                .Select(x => x.Slot)
                 .FirstOrDefault();
         }
     }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using ECommons.Automation.UIInput;
 using ItemSlot = GatherBuddy.AutoGather.GatheringTracker.ItemSlot;
 using Dalamud.Game.ClientState.Conditions;
+using GatherBuddy.AutoGather.Extensions;
 
 namespace GatherBuddy.AutoGather
 {
@@ -66,7 +67,7 @@ namespace GatherBuddy.AutoGather
 
             var target = targetItem != null ? available.Where(s => s.Item == targetItem).FirstOrDefault() : null;
 
-            if (target != null && InventoryCount(targetItem!) < QuantityTotal(targetItem!))
+            if (target != null && targetItem!.GetInventoryCount() < QuantityTotal(targetItem!))
             {
                 //The target item is found in the node, would not overcap and we need to gather more of it
                 return (!target.Collectable, target);
@@ -77,14 +78,14 @@ namespace GatherBuddy.AutoGather
                 //Join node slots, retaining list order
                 .Join(available, i => i.Item, s => s.Item, (i, s) => s)
                 //And we need more of them
-                .Where(s => InventoryCount(s.Item) < QuantityTotal(s.Item));
+                .Where(s => s.Item.GetInventoryCount() < QuantityTotal(s.Item));
 
             //Items in the fallback list
             var fallbackList = _plugin.AutoGatherListsManager.FallbackItems
                 //Join node slots, retaining list order
                 .Join(available, i => i.Item, s => s.Item, (i, s) => (Slot: s, i.Quantity))
                 //And we need more of them
-                .Where(x => InventoryCount(x.Slot.Item) < x.Quantity)
+                .Where(x => x.Slot.Item.GetInventoryCount() < x.Quantity)
                 .Select(x => x.Slot);
 
             var fallbackSkills = GatherBuddy.Config.AutoGatherConfig.UseSkillsForFallbackItems;
@@ -132,10 +133,10 @@ namespace GatherBuddy.AutoGather
         private bool CheckItemOvercap(ItemSlot s)
         {
             //If it's a treasure map, we can have only one in the inventory
-            if (s.Item.IsTreasureMap && InventoryCount(s.Item) != 0)
+            if (s.Item.IsTreasureMap && s.Item.GetInventoryCount() != 0)
                 return false;
             //If it's a crystal, we can't have more than 9999
-            if (s.Item.IsCrystal && InventoryCount(s.Item) > 9999 - s.Yield)
+            if (s.Item.IsCrystal && s.Item.GetInventoryCount() > 9999 - s.Yield)
                 return false;
             return true;
         }
@@ -148,7 +149,7 @@ namespace GatherBuddy.AutoGather
                 //Prioritize crystals in the gathering list
                 .OrderBy(s => ItemsToGather.Any(g => g.Item == s.Item) ? 0 : 1)
                 //Prioritize crystals with a lower amount in the inventory
-                .ThenBy(s => InventoryCount(s.Item))
+                .ThenBy(s => s.Item.GetInventoryCount())
                 .FirstOrDefault();
         }
     }

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -147,7 +147,7 @@ namespace GatherBuddy.AutoGather
                 .Where(s => s.Item.IsCrystal)
                 .Where(CheckItemOvercap)
                 //Prioritize crystals in the gathering list
-                .OrderBy(s => ItemsToGather.Any(g => g.Item == s.Item) ? 0 : 1)
+                .OrderBy(s => _activeItemList.Contains(s.Item) ? 0 : 1)
                 //Prioritize crystals with a lower amount in the inventory
                 .ThenBy(s => s.Item.GetInventoryCount())
                 .FirstOrDefault();

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -42,7 +42,7 @@ namespace GatherBuddy.AutoGather
             {
                 TaskManager.Enqueue(() => Dalamud.Conditions[ConditionFlag.Gathering42], 1000);
                 TaskManager.Enqueue(() => !Dalamud.Conditions[ConditionFlag.Gathering42]);
-                TaskManager.Enqueue(RefreshNextTreasureMapAllowance);
+                TaskManager.Enqueue(DiscipleOfLand.RefreshNextTreasureMapAllowance);
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -87,7 +87,7 @@ namespace GatherBuddy.AutoGather
                         {
                             try
                             {
-                                var floor = VNavmesh_IPCSubscriber.Query_Mesh_PointOnFloor(Player.Position, false, 3);
+                                var floor = VNavmesh.Query.Mesh.PointOnFloor(Player.Position, false, 3);
                                 Navigate(floor, true);
                                 TaskManager.Enqueue(() => !IsPathGenerating);
                                 TaskManager.DelayNext(50);
@@ -164,10 +164,9 @@ namespace GatherBuddy.AutoGather
             // Reset navigation logic here
             // For example, reinitiate navigation to the destination
             CurrentDestination = default;
-            if (VNavmesh_IPCSubscriber.IsEnabled)
+            if (VNavmesh.Enabled)
             {
-                //VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
-                VNavmesh_IPCSubscriber.Path_Stop();
+                VNavmesh.Path.Stop();
             }
             lastResetTime = DateTime.Now;
         }
@@ -193,7 +192,7 @@ namespace GatherBuddy.AutoGather
             var correctedDestination = GetCorrectedDestination(CurrentDestination);
             GatherBuddy.Log.Debug($"Navigating to {destination} (corrected to {correctedDestination})");
 
-            LastNavigationResult = VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(correctedDestination, shouldFly);
+            LastNavigationResult = VNavmesh.SimpleMove.PathfindAndMoveTo(correctedDestination, shouldFly);
         }
 
         private static Vector3 GetCorrectedDestination(Vector3 destination)
@@ -206,7 +205,7 @@ namespace GatherBuddy.AutoGather
                 float separation;
                 if (WorldData.NodeOffsets.TryGetValue(destination, out var offset))
                 {
-                    offset = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(offset, MaxHorizontalSeparation, MaxVerticalSeparation);
+                    offset = VNavmesh.Query.Mesh.NearestPoint(offset, MaxHorizontalSeparation, MaxVerticalSeparation);
                     if ((separation = Vector2.Distance(offset.ToVector2(), destination.ToVector2())) > MaxHorizontalSeparation)
                         GatherBuddy.Log.Warning($"Offset is ignored because the horizontal separation {separation} is too large after correcting for mesh. Maximum allowed is {MaxHorizontalSeparation}.");
                     else if ((separation = Math.Abs(offset.Y - destination.Y)) > MaxVerticalSeparation)
@@ -215,11 +214,11 @@ namespace GatherBuddy.AutoGather
                         return offset;
                 }
 
-                var correctedDestination = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(destination, MaxHorizontalSeparation, MaxVerticalSeparation);
+                var correctedDestination = VNavmesh.Query.Mesh.NearestPoint(destination, MaxHorizontalSeparation, MaxVerticalSeparation);
                 if ((separation = Vector2.Distance(correctedDestination.ToVector2(), destination.ToVector2())) > MaxHorizontalSeparation)
-                    GatherBuddy.Log.Warning($"Query_Mesh_NearestPoint() returned a point with too large horizontal separation {separation}. Maximum allowed is {MaxHorizontalSeparation}.");
+                    GatherBuddy.Log.Warning($"Query.Mesh.NearestPoint() returned a point with too large horizontal separation {separation}. Maximum allowed is {MaxHorizontalSeparation}.");
                 else if ((separation = Math.Abs(correctedDestination.Y - destination.Y)) > MaxVerticalSeparation)
-                    GatherBuddy.Log.Warning($"Query_Mesh_NearestPoint() returned a point with too large vertical separation {separation}. Maximum allowed is {MaxVerticalSeparation}.");
+                    GatherBuddy.Log.Warning($"Query.Mesh.NearestPoint() returned a point with too large vertical separation {separation}. Maximum allowed is {MaxVerticalSeparation}.");
                 else
                     return correctedDestination;
             }

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -205,14 +205,14 @@ namespace GatherBuddy.AutoGather
                 if (WorldData.NodeOffsets.TryGetValue(destination, out var offset))
                 {
                     offset = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(offset, 3, 3);
-                    if ((distance = Vector2.Distance(offset.ToVector2(), destination.ToVector2())) > 3.5f)
+                    if ((distance = Vector2.Distance(offset.ToVector2(), destination.ToVector2())) > 3)
                         GatherBuddy.Log.Warning($"Offset is ignored because the distance {distance} is too large after correcting for mesh.");
                     else
                         return offset;
                 }
 
                 var correctedDestination = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(destination, 3, 3);
-                if ((distance = Vector2.Distance(correctedDestination.ToVector2(), destination.ToVector2())) > 3.5f)
+                if ((distance = Vector2.Distance(correctedDestination.ToVector2(), destination.ToVector2())) > 3)
                     GatherBuddy.Log.Warning($"Query_Mesh_NearestPoint() returned a point that is too far away from the node (distance {distance}).");
                 else 
                     return correctedDestination;

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -101,7 +101,7 @@ namespace GatherBuddy.AutoGather
                 {
                     StopNavigation();
                     AutoStatus = "Waiting for GP to regenerate...";
-                } 
+                }
                 else
                 {
                     // Use consumables with cast time just before gathering a node when player is surely not mounted
@@ -114,6 +114,14 @@ namespace GatherBuddy.AutoGather
                     }
                     else
                     {
+                        // Check perception requirement before interacting with node
+                        if (CharacterPerceptionStat < targetItem.GatheringData.PerceptionReq)
+                        {
+                            Communicator.PrintError($"Insufficient Perception to gather this item. Required: {targetItem.GatheringData.PerceptionReq}, current: {CharacterPerceptionStat}");
+                            AbortAutoGather();
+                            return;
+                        }
+
                         EnqueueNodeInteraction(gameObject, targetItem);
                         //The node could be behind a rock or a tree and not be interactable. This happened in the Endwalker, but seems not to be reproducible in the Dawntrail.
                         //Enqueue navigation anyway, just in case.

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -205,14 +205,14 @@ namespace GatherBuddy.AutoGather
                 if (WorldData.NodeOffsets.TryGetValue(destination, out var offset))
                 {
                     offset = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(offset, 3, 3);
-                    if ((distance = Vector2.Distance(offset.ToVector2(), destination.ToVector2())) > 3)
+                    if ((distance = Vector2.Distance(offset.ToVector2(), destination.ToVector2())) > 3.5f)
                         GatherBuddy.Log.Warning($"Offset is ignored because the distance {distance} is too large after correcting for mesh.");
                     else
                         return offset;
                 }
 
                 var correctedDestination = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(destination, 3, 3);
-                if ((distance = Vector2.Distance(correctedDestination.ToVector2(), destination.ToVector2())) > 3)
+                if ((distance = Vector2.Distance(correctedDestination.ToVector2(), destination.ToVector2())) > 3.5f)
                     GatherBuddy.Log.Warning($"Query_Mesh_NearestPoint() returned a point that is too far away from the node (distance {distance}).");
                 else 
                     return correctedDestination;

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -119,9 +119,9 @@ namespace GatherBuddy.AutoGather
                     else
                     {
                         // Check perception requirement before interacting with node
-                        if (CharacterPerceptionStat < targetItem.GatheringData.PerceptionReq)
+                        if (DiscipleOfLand.Perception < targetItem.GatheringData.PerceptionReq)
                         {
-                            Communicator.PrintError($"Insufficient Perception to gather this item. Required: {targetItem.GatheringData.PerceptionReq}, current: {CharacterPerceptionStat}");
+                            Communicator.PrintError($"Insufficient Perception to gather this item. Required: {targetItem.GatheringData.PerceptionReq}, current: {DiscipleOfLand.Perception}");
                             AbortAutoGather();
                             return;
                         }

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -236,7 +236,7 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        private static Aetheryte? FindClosestAetheryte(ILocation location)
+        public static Aetheryte? FindClosestAetheryte(ILocation location)
         {
             var aetheryte = location.ClosestAetheryte;
 
@@ -254,40 +254,6 @@ namespace GatherBuddy.AutoGather
 
             return aetheryte;
         }
-
-        private uint GetTeleportationCost(GatheringNode location)
-        {
-            var territory = Dalamud.ClientState.TerritoryType;
-            if (territory != TeleportationCostCacheTerritory)
-                UpdateTeleportationCosts();
-            if (territory != TeleportationCostCacheTerritory)
-                return uint.MaxValue;
-
-            var aetheryte = FindClosestAetheryte(location);
-            if (aetheryte == null)
-                return uint.MaxValue; // If there's no aetheryte, put it at the end
-
-            return TeleportationCostCache.GetValueOrDefault(aetheryte.Id, uint.MaxValue);
-        }
-
-        private unsafe void UpdateTeleportationCosts()
-        {
-            TeleportationCostCache.Clear();
-            TeleportationCostCacheTerritory = 0;
-
-            var telepo = Telepo.Instance();
-            if (telepo == null) return;
-
-            telepo->UpdateAetheryteList();
-
-            for (var i = 0; i < telepo->TeleportList.Count; i++)
-            {
-                var entry = telepo->TeleportList[i];
-                TeleportationCostCache[entry.AetheryteId] = entry.GilCost;
-            }
-            TeleportationCostCacheTerritory = Dalamud.ClientState.TerritoryType;
-        }
-
 
         private bool MoveToTerritory(ILocation location)
         {

--- a/GatherBuddy/AutoGather/AutoGather.Purify.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Purify.cs
@@ -1,0 +1,96 @@
+﻿using FFXIVClientStructs.FFXIV.Client.Game;
+using GatherBuddy.Plugin;
+using Dalamud.Game.ClientState.Conditions;
+using PurifyResult = ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.PurifyResult;
+using ECommons.Automation;
+using ECommons.DalamudServices;
+
+namespace GatherBuddy.AutoGather
+{
+    public partial class AutoGather
+    {
+        private bool HasReducibleItems()
+        {
+            if (!GatherBuddy.Config.AutoGatherConfig.DoReduce || Svc.Condition[ConditionFlag.Mounted]) return false;
+
+            if (!QuestManager.IsQuestComplete(67633)) // No Longer a Collectable
+            {
+                GatherBuddy.Config.AutoGatherConfig.DoReduce = false;
+                Communicator.PrintError("[GatherBuddyReborn] Aetherial reduction is enabled, but the relevant quest has not been completed yet. The feature has been disabled.");
+                return false;
+            }
+
+            unsafe
+            {
+                var manager = InventoryManager.Instance();
+                if (manager == null)
+                    return false;
+
+                foreach (var invType in InventoryTypes)
+                {
+                    var container = manager->GetInventoryContainer(invType);
+                    if (container == null || !container->IsLoaded)
+                        continue;
+
+                    for (int i = 0; i < container->Size; i++)
+                    {
+                        var slot = container->GetInventorySlot(i);
+                        if (slot != null
+                            && slot->ItemId != 0
+                            && GatherBuddy.GameData.Gatherables.TryGetValue(slot->ItemId, out var gatherable)
+                            && gatherable.ItemData.AetherialReduce != 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        }
+
+        private unsafe void ReduceItems(bool reduceAll)
+        {
+            AutoStatus = "Aetherial reduction";
+            var delay = (int)GatherBuddy.Config.AutoGatherConfig.ExecutionDelay;
+            TaskManager.Enqueue(StopNavigation);
+            if (PurifyItemSelectorAddon == null)
+            {
+                EnqueueActionWithDelay(() => { ActionManager.Instance()->UseAction(ActionType.GeneralAction, 21); });
+                // Prevent the "Unable to execute command while occupied" message right after entering a house.
+                TaskManager.DelayNext(500);
+            }
+
+            TaskManager.Enqueue(ReduceFirstItem, 3000, true, "Reduce first item");
+            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39], 5000, true, "Wait until first item reduction is complete");
+            TaskManager.DelayNext(delay);
+            TaskManager.Enqueue(StartAutoReduction, 1000, true, "Start auto reduction");
+            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39], 180000, true, "Wait until all items have been reduced");
+            TaskManager.DelayNext(delay);
+            TaskManager.Enqueue(() => {
+                EnqueueActionWithDelay(() => { if (PurifyResultAddon is var addon and not null) Callback.Fire(addon, true, -1); });
+                if (reduceAll && HasReducibleItems())
+                    ReduceItems(true);
+                else
+                    EnqueueActionWithDelay(() => { if (PurifyItemSelectorAddon is var addon and not null) Callback.Fire(addon, true, -1); });
+            });
+        }
+
+        private unsafe bool? ReduceFirstItem()
+        {
+            var addon = PurifyItemSelectorAddon;
+            if (addon == null) return false;
+
+            Callback.Fire(addon, true, 12, 0u);
+            return true;
+        }
+
+        private unsafe bool? StartAutoReduction()
+        {
+            var addon = PurifyResultAddon;
+            if (addon == null) return false;
+
+            new PurifyResult(addon).Automatic();
+            return true;
+        }
+    }
+}

--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -56,7 +56,7 @@ public partial class AutoGather
 
         if (SpiritbondMax == 1) 
         {
-            EnqueueActionWithDelay(() => { if (MaterializeAddon is var addon and not null) addon->Close(true); });
+            EnqueueActionWithDelay(() => { if (MaterializeAddon is var addon and not null) Callback.Fire(&addon->AtkUnitBase, true, -1); });
         }
     }
 }

--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -14,6 +14,8 @@ public partial class AutoGather
     {
         get
         {
+            if (!GatherBuddy.Config.AutoGatherConfig.DoMaterialize) return 0;
+
             var inventory = InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems);
             var result    = 0;
             for (var slot = 0; slot < inventory->Size; slot++)

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -137,8 +137,8 @@ namespace GatherBuddy.AutoGather
                             return;
                         }
                         //VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
-                        VNavmesh_IPCSubscriber.Path_Stop();
-                        VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(node.Position, GatherBuddy.AutoGather.ShouldFly(node.Position));
+                        VNavmesh.Path.Stop();
+                        VNavmesh.SimpleMove.PathfindAndMoveTo(node.Position, GatherBuddy.AutoGather.ShouldFly(node.Position));
                     }
 
                     if (WorldData.NodeOffsets.TryGetValue(node.Position, out var offset))
@@ -157,8 +157,8 @@ namespace GatherBuddy.AutoGather
                                 return;
                             }
                             //VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
-                            VNavmesh_IPCSubscriber.Path_Stop();
-                            VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(offset, GatherBuddy.AutoGather.ShouldFly(offset));
+                            VNavmesh.Path.Stop();
+                            VNavmesh.SimpleMove.PathfindAndMoveTo(offset, GatherBuddy.AutoGather.ShouldFly(offset));
                         }
                     }
                     else

--- a/GatherBuddy/AutoGather/AutoGather.Ui.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Ui.cs
@@ -79,7 +79,7 @@ namespace GatherBuddy.AutoGather
 
                 ImGui.TableHeadersRow();
 
-                var playerPosition = Player.Object.Position;
+                var playerPosition = Player.Object?.Position ?? Vector3.Zero;
                 foreach (var node in Svc.Objects.Where(o => o.ObjectKind == ObjectKind.GatheringPoint)
                              .OrderBy(o => Vector3.Distance(o.Position, playerPosition)))
                 {
@@ -93,7 +93,7 @@ namespace GatherBuddy.AutoGather
                     ImGui.TableSetColumnIndex(3);
                     ImGui.Text(node.Position.ToString());
                     ImGui.TableSetColumnIndex(4);
-                    var distance = Vector3.Distance(Player.Object.Position, node.Position);
+                    var distance = Vector3.Distance(playerPosition, node.Position);
                     ImGui.Text(distance.ToString());
                     ImGui.TableSetColumnIndex(5);
 
@@ -101,7 +101,7 @@ namespace GatherBuddy.AutoGather
                     var isBlacklisted = GatherBuddy.Config.AutoGatherConfig.BlacklistedNodesByTerritoryId.TryGetValue(territoryId, out var list)
                      && list.Contains(node.Position);
 
-                    if (isBlacklisted)
+                    if (isBlacklisted && list != null)
                     {
                         if (ImGui.Button($"Unblacklist##{node.Position}"))
                         {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -13,7 +13,6 @@ using GatherBuddy.Enums;
 using GatherBuddy.Time;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using System.Collections.Specialized;
-using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using NodeType = GatherBuddy.Enums.NodeType;
 using Dalamud.Utility;
@@ -118,10 +117,6 @@ namespace GatherBuddy.AutoGather
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
 
-        private static int MinerExpArrayIndex { get; } = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.MIN).ExpArrayIndex;
-        private static int BotanistExpArrayIndex { get; } = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.BTN).ExpArrayIndex;
-        private static unsafe int GetMinerLevel() => PlayerState.Instance()->ClassJobLevels[MinerExpArrayIndex];
-        private static unsafe int GetBotanistLevel() => PlayerState.Instance()->ClassJobLevels[BotanistExpArrayIndex];
 
         public void UpdateItemsToGather()
         {
@@ -156,8 +151,8 @@ namespace GatherBuddy.AutoGather
         private GatherInfo GetBestLocation(Gatherable item)
         {
             // Items are unlocked in tiers of 5 levels, so we round up to the nearest 5.
-            var minerLevel = (GetMinerLevel() + 4) / 5 * 5;
-            var botanistLevel = (GetBotanistLevel() + 4) / 5 * 5;
+            var minerLevel = (DiscipleOfLand.MinerLevel + 4) / 5 * 5;
+            var botanistLevel = (DiscipleOfLand.BotanistLevel + 4) / 5 * 5;
             // Preferred location from the list if set.
             var pref = _plugin.AutoGatherListsManager.GetPreferredLocation(item);
             var nodes = item.NodeList
@@ -312,12 +307,6 @@ namespace GatherBuddy.AutoGather
 
         private static TimeStamp AdjustedServerTime
             => GatherBuddy.Time.ServerTime.AddSeconds(GatherBuddy.Config.AutoGatherConfig.TimedNodePrecog);
-
-        private static unsafe int CharacterGatheringStat
-            => PlayerState.Instance()->Attributes[72];
-
-        private static unsafe int CharacterPerceptionStat
-            => PlayerState.Instance()->Attributes[73];
 
         private ConfigPreset MatchConfigPreset(Gatherable? item) => _plugin.Interface.MatchConfigPreset(item);
     }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -43,6 +43,14 @@ namespace GatherBuddy.AutoGather
         public Vector3 CurrentDestination { get; private set; } = default;
         private ILocation? CurrentFarNodeLocation;
 
+        public static IReadOnlyList<InventoryType> InventoryTypes { get; } =
+        [
+            InventoryType.Inventory1,
+            InventoryType.Inventory2,
+            InventoryType.Inventory3,
+            InventoryType.Inventory4,
+        ];
+
         public GatheringType JobAsGatheringType
         {
             get
@@ -112,7 +120,7 @@ namespace GatherBuddy.AutoGather
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
 
-        private unsafe T* GetAddon<T>(string name)
+        private static unsafe T* GetAddon<T>(string name) where T : unmanaged
         {
             var addon = (AtkUnitBase*)Dalamud.GameGui.GetAddonByName(name);
             if (addon != null && addon->IsFullyLoaded() && addon->IsReady)
@@ -120,20 +128,26 @@ namespace GatherBuddy.AutoGather
             else
                 return null;
         }
-        public unsafe AddonGathering* GatheringAddon
+        public static unsafe AddonGathering* GatheringAddon
             => GetAddon<AddonGathering>("Gathering");
 
-        public unsafe AddonGatheringMasterpiece* MasterpieceAddon
+        public static unsafe AddonGatheringMasterpiece* MasterpieceAddon
             => GetAddon<AddonGatheringMasterpiece>("GatheringMasterpiece");
 
-        public unsafe AddonMaterializeDialog* MaterializeAddon
+        public static unsafe AddonMaterializeDialog* MaterializeAddon
             => GetAddon<AddonMaterializeDialog>("Materialize");
 
-        public unsafe AddonMaterializeDialog* MaterializeDialogAddon
+        public static unsafe AddonMaterializeDialog* MaterializeDialogAddon
             => GetAddon<AddonMaterializeDialog>("MaterializeDialog");
 
-        public unsafe AddonSelectYesno* SelectYesnoAddon
+        public static unsafe AddonSelectYesno* SelectYesnoAddon
             => GetAddon<AddonSelectYesno>("SelectYesno");
+
+        public static unsafe AtkUnitBase* PurifyItemSelectorAddon
+            => GetAddon<AtkUnitBase>("PurifyItemSelector");
+
+        public static unsafe AtkUnitBase* PurifyResultAddon
+            => GetAddon<AtkUnitBase>("PurifyResult");
 
         public IEnumerable<IGatherable> ItemsToGatherInZone
             => _activeItemList.Where(i => i.Node?.Territory.Id == Dalamud.ClientState.TerritoryType).Select(i => i.Item);
@@ -149,6 +163,8 @@ namespace GatherBuddy.AutoGather
                     return false;
                 if (Dalamud.Conditions[ConditionFlag.BetweenAreas]
                  || Dalamud.Conditions[ConditionFlag.BetweenAreas51]
+                 || Dalamud.Conditions[ConditionFlag.OccupiedInQuestEvent]
+                 || Dalamud.Conditions[ConditionFlag.OccupiedSummoningBell]
                  || Dalamud.Conditions[ConditionFlag.BeingMoved]
                  || Dalamud.Conditions[ConditionFlag.Casting]
                  || Dalamud.Conditions[ConditionFlag.Casting87]
@@ -161,7 +177,7 @@ namespace GatherBuddy.AutoGather
                  || Dalamud.Conditions[ConditionFlag.Gathering42]
                  //Node is open? Fades off shortly after closing the node, can't use items (but can mount) while it's set
                  || Dalamud.Conditions[85] && !Dalamud.Conditions[ConditionFlag.Gathering]
-                 || Dalamud.ClientState.LocalPlayer.CurrentHp < 1
+                 || Dalamud.ClientState.LocalPlayer.IsDead
                  || Player.IsAnimationLocked)
                     return false;
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -188,6 +188,16 @@ namespace GatherBuddy.AutoGather
                 })
                 // Prioritize nodes in the current territory.
                 .ThenBy(info => info.Location.Territory.Id != Dalamud.ClientState.TerritoryType)
+                // Prioritize closest nodes in the current territory.
+                .ThenBy(info =>
+                {
+                    if (info.Location.Territory.Id != Dalamud.ClientState.TerritoryType)
+                        return 0f;
+                    // Node coordinates are map coordinates multiplied by 100.
+                    var playerPos3D = Player.Object.GetMapCoordinates();
+                    var playerPos = new Vector2(playerPos3D.X * 100f, playerPos3D.Y * 100f);
+                    return Vector2.DistanceSquared(new Vector2(info.Location.IntegralXCoord, info.Location.IntegralYCoord), playerPos);
+                })
                 // Order by end time, longest first as in the original UptimeManager.NextUptime().
                 .ThenByDescending(info => info.Time.End);
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -107,7 +107,7 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        public string AutoStatus { get; set; } = "Idle";
+        public string AutoStatus { get; private set; } = "Idle";
         public int LastCollectability = 0;
         public int LastIntegrity = 0;
         private BitVector32 LuckUsed;

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -185,9 +185,6 @@ namespace GatherBuddy.AutoGather
             }
         }
 
-        private uint QuantityTotal(IGatherable gatherable)
-            => _plugin.AutoGatherListsManager.GetTotalQuantitiesForItem(gatherable);
-
         private static unsafe bool HasGivingLandBuff
             => Dalamud.ClientState.LocalPlayer?.StatusList.Any(s => s.StatusId == 1802) ?? false;
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -107,85 +107,80 @@ namespace GatherBuddy.AutoGather
         private bool WentHome;
 
         public readonly List<GatherInfo> ItemsToGather = [];
-        public readonly Dictionary<ILocation, TimeInterval> VisitedTimedLocations = [];
+        public readonly Dictionary<GatheringNode, TimeInterval> VisitedTimedLocations = [];
         public readonly HashSet<Vector3> FarNodesSeenSoFar = [];
         public readonly LinkedList<uint> VisitedNodes = [];
         private GatherInfo? targetInfo = null;
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
 
+        private static int MinerExpArrayIndex { get; } = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.MIN).ExpArrayIndex;
+        private static int BotanistExpArrayIndex { get; } = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.BTN).ExpArrayIndex;
+        private static unsafe int GetMinerLevel() => PlayerState.Instance()->ClassJobLevels[MinerExpArrayIndex];
+        private static unsafe int GetBotanistLevel() => PlayerState.Instance()->ClassJobLevels[BotanistExpArrayIndex];
+
         public void UpdateItemsToGather()
         {
             ItemsToGather.Clear();
-            var activeItems = OrderActiveItems(_plugin.AutoGatherListsManager.ActiveItems.OfType<Gatherable>().Select(GetBestLocation));
-            var RegularItemsToGather = new List<GatherInfo>();
-            foreach (var (item, location, time) in activeItems)
+            var activeItems = _plugin.AutoGatherListsManager.ActiveItems.OfType<Gatherable>()
+                // Not gathered enough.
+                .Where(item => InventoryCount(item) < QuantityTotal(item))
+                // If treasure map, only gather if we have none or the allowance is up.
+                .Where(item => !item.IsTreasureMap || InventoryCount(item) == 0 && NextTreasureMapAllowance < AdjustedServerTime.DateTime)
+                // Choose the best location and calculate the next uptime.
+                .Select(GetBestLocation)
+                // Filter out items that are not available right now or don't have an unvisited location.
+                .OfType<GatherInfo>()
+                // Prioritize timed nodes first.
+                .OrderBy(info => info.Time == TimeInterval.Always);
+
+            if (GatherBuddy.Config.AutoGatherConfig.SortingMethod == AutoGatherConfig.SortingType.Location)
             {
-                uint quest = item.GatheringType switch
-                {
-                    GatheringType.Miner    => 65728,
-                    GatheringType.Botanist => 65729,
-                    _                      => 0,
-                };
-                if (quest > 0 && !QuestManager.IsQuestComplete(quest))
-                {
-                    GatherBuddy.Log.Warning($"{item.Name} was requested but {item.GatheringType} is not unlocked");
-                    continue;
-                }
-                if (InventoryCount(item) >= QuantityTotal(item) || item.IsTreasureMap && InventoryCount(item) > 0)
-                    continue;
-
-                if (item.IsTreasureMap && NextTreasureMapAllowance >= AdjustedServerTime.DateTime)
-                    continue;
-
-                if (GatherBuddy.UptimeManager.TimedGatherables.Contains(item))
-                {
-                    if (time.InRange(AdjustedServerTime))
-                        ItemsToGather.Add((item, location, time));
-                }
-                else
-                {
-                    RegularItemsToGather.Add((item, location, time));
-                }
+                activeItems = activeItems
+                    // Order by node type.
+                    .ThenBy(info => GetNodeTypeAsPriority(info.Item))
+                    // Then by territory.
+                    .ThenBy(info => info.Location.Territory.Id);
             }
-            ItemsToGather.Sort((x, y) => GetNodeTypeAsPriority(x.Item).CompareTo(GetNodeTypeAsPriority(y.Item)));
-            ItemsToGather.AddRange(RegularItemsToGather);
+
+            ItemsToGather.AddRange(activeItems);
         }
 
-        private GatherInfo GetBestLocation(Gatherable item)
+        private GatherInfo? GetBestLocation(Gatherable item)
         {
-            (ILocation? Location, TimeInterval Time) res = default;
-            //First priority: selected preferred location.
-            var node = _plugin.AutoGatherListsManager.GetPreferredLocation(item);
-            var time = AdjustedServerTime;
-            if (node != null && !VisitedTimedLocations.ContainsKey(node))
-            {
-                res = (node, node.Times.NextUptime(time));
-            }
-            //Second priority: location for preferred job.
-            if ((res.Location == null || !res.Time.InRange(time)) && GatherBuddy.Config.PreferredGatheringType is GatheringType.Miner or GatheringType.Botanist)
-            {
-                res = GatherBuddy.UptimeManager.NextUptime(item, GatherBuddy.Config.PreferredGatheringType, time, [.. VisitedTimedLocations.Keys]);
-            }
-            //Otherwise: location for any job.
-            if (res.Location == null || !res.Time.InRange(time))
-            {
-                res = GatherBuddy.UptimeManager.NextUptime(item, time, [.. VisitedTimedLocations.Keys]);
-            }
-            return (item, (GatheringNode?)res.Location, res.Time);
-        }
+            // Items are unlocked in tiers of 5 levels, so we round up to the nearest 5.
+            var minerLevel = (GetMinerLevel() + 4) / 5 * 5;
+            var botanistLevel = (GetBotanistLevel() + 4) / 5 * 5;
+            // Preferred location from the list if set.
+            var pref = _plugin.AutoGatherListsManager.GetPreferredLocation(item);
+            var nodes = item.NodeList
+                // Remove nodes that have been visited.
+                .Except(VisitedTimedLocations.Keys)
+                // Remove nodes with level higher than the player can gather.
+                .Where(node => node.GatheringType.ToGroup() switch
+                {
+                    GatheringType.Miner => node.Level <= minerLevel,
+                    GatheringType.Botanist => node.Level <= botanistLevel,
+                    _ => false
+                })
+                // Get next uptime.
+                .Select(node => new GatherInfo(item, node, node.Times.NextUptime(AdjustedServerTime)))
+                // Filter out nodes that are not up. Also filter out invalid intervals.
+                .Where(info => info.Time.InRange(AdjustedServerTime))
+                // Prioritize preferred location, then preferred job, then the rest.
+                .OrderBy(info =>
+                {
+                    if (info.Location == pref)
+                        return 0;
+                    if (info.Location.GatheringType.ToGroup() == GatherBuddy.Config.PreferredGatheringType)
+                        return 1;
+                    return 2;
+                })
+                // Order by end time, longest first as in original UptimeManager.NextUptime().
+                .ThenByDescending(info => info.Time.End);
 
-        private IEnumerable<GatherInfo> OrderActiveItems(IEnumerable<GatherInfo> activeItems)
-        {
-            switch (GatherBuddy.Config.AutoGatherConfig.SortingMethod)
-            {
-                case AutoGatherConfig.SortingType.Location: return activeItems.OrderBy(i => i.Location?.Territory.Id);
-                case AutoGatherConfig.SortingType.None:
-                default:
-                    return activeItems;
-            }
+            return nodes.FirstOrDefault();
         }
-
 
         private unsafe T* GetAddon<T>(string name)
         {
@@ -252,19 +247,15 @@ namespace GatherBuddy.AutoGather
 
         private int GetNodeTypeAsPriority(Gatherable item)
         {
-            if (GatherBuddy.Config.AutoGatherConfig.SortingMethod == AutoGatherConfig.SortingType.None)
-                return 0;
-            Gatherable gatherable = item;
-            switch (gatherable?.NodeType)
+            return item.NodeType switch
             {
-                case NodeType.Legendary: return 0;
-                case NodeType.Unspoiled: return 1;
-                case NodeType.Ephemeral: return 2;
-                case NodeType.Regular:   return 9;
-                case NodeType.Unknown:   return 99;
-            }
-
-            return 99;
+                NodeType.Legendary => 0,
+                NodeType.Unspoiled => 1,
+                NodeType.Ephemeral => 2,
+                NodeType.Regular => 9,
+                NodeType.Unknown => 99,
+                _ => 99,
+            };
         }
 
         private static unsafe bool HasGivingLandBuff
@@ -292,16 +283,16 @@ namespace GatherBuddy.AutoGather
             => PlayerState.Instance()->Attributes[73];
 
         private ConfigPreset MatchConfigPreset(Gatherable? item) => _plugin.Interface.MatchConfigPreset(item);
-}
+    }
 
-    public record class GatherInfo(Gatherable Item, GatheringNode? Location, TimeInterval Time)
+    public record class GatherInfo(Gatherable Item, GatheringNode Location, TimeInterval Time)
     {
-        public static implicit operator (Gatherable Item, GatheringNode? Location, TimeInterval Time)(GatherInfo value)
+        public static implicit operator (Gatherable Item, GatheringNode Location, TimeInterval Time)(GatherInfo value)
         {
             return (value.Item, value.Location, value.Time);
         }
 
-        public static implicit operator GatherInfo((Gatherable Item, GatheringNode? Location, TimeInterval Time) value)
+        public static implicit operator GatherInfo((Gatherable Item, GatheringNode Location, TimeInterval Time) value)
         {
             return new GatherInfo(value.Item, value.Location, value.Time);
         }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -21,13 +21,13 @@ namespace GatherBuddy.AutoGather
     public partial class AutoGather
     {
         public bool IsPathing
-            => VNavmesh_IPCSubscriber.Path_IsRunning();
+            => VNavmesh.Path.IsRunning();
 
         public bool IsPathGenerating
-            => VNavmesh_IPCSubscriber.Nav_PathfindInProgress();
+            => VNavmesh.Nav.PathfindInProgress();
 
         public bool NavReady
-            => VNavmesh_IPCSubscriber.Nav_IsReady();
+            => VNavmesh.Nav.IsReady();
 
         private bool IsBlacklisted(Vector3 g)
         {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -288,6 +288,9 @@ namespace GatherBuddy.AutoGather
         private static unsafe int CharacterGatheringStat
             => PlayerState.Instance()->Attributes[72];
 
+        private static unsafe int CharacterPerceptionStat
+            => PlayerState.Instance()->Attributes[73];
+
         private ConfigPreset MatchConfigPreset(Gatherable? item) => _plugin.Interface.MatchConfigPreset(item);
 }
 

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -110,7 +110,7 @@ namespace GatherBuddy.AutoGather
         public readonly Dictionary<GatheringNode, TimeInterval> VisitedTimedLocations = [];
         public readonly HashSet<Vector3> FarNodesSeenSoFar = [];
         public readonly LinkedList<uint> VisitedNodes = [];
-        private GatherInfo? targetInfo = null;
+        private GatherInfo targetInfo;
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
 
@@ -130,7 +130,7 @@ namespace GatherBuddy.AutoGather
                 // Choose the best location and calculate the next uptime.
                 .Select(GetBestLocation)
                 // Filter out items that are not available right now or don't have an unvisited location.
-                .OfType<GatherInfo>()
+                .Where(info => info != default)
                 // Prioritize timed nodes first.
                 .OrderBy(info => info.Time == TimeInterval.Always);
 
@@ -146,7 +146,7 @@ namespace GatherBuddy.AutoGather
             ItemsToGather.AddRange(activeItems);
         }
 
-        private GatherInfo? GetBestLocation(Gatherable item)
+        private GatherInfo GetBestLocation(Gatherable item)
         {
             // Items are unlocked in tiers of 5 levels, so we round up to the nearest 5.
             var minerLevel = (GetMinerLevel() + 4) / 5 * 5;
@@ -285,7 +285,7 @@ namespace GatherBuddy.AutoGather
         private ConfigPreset MatchConfigPreset(Gatherable? item) => _plugin.Interface.MatchConfigPreset(item);
     }
 
-    public record class GatherInfo(Gatherable Item, GatheringNode Location, TimeInterval Time)
+    public record struct GatherInfo(Gatherable Item, GatheringNode Location, TimeInterval Time)
     {
         public static implicit operator (Gatherable Item, GatheringNode Location, TimeInterval Time)(GatherInfo value)
         {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -17,6 +17,7 @@ using FFXIVClientStructs.FFXIV.Component.GUI;
 using NodeType = GatherBuddy.Enums.NodeType;
 using Dalamud.Utility;
 using GatherBuddy.Config;
+using GatherBuddy.AutoGather.Extensions;
 
 namespace GatherBuddy.AutoGather
 {
@@ -123,9 +124,9 @@ namespace GatherBuddy.AutoGather
             ItemsToGather.Clear();
             var activeItems = _plugin.AutoGatherListsManager.ActiveItems.OfType<Gatherable>()
                 // Not gathered enough.
-                .Where(item => InventoryCount(item) < QuantityTotal(item))
+                .Where(item => item.GetInventoryCount() < QuantityTotal(item))
                 // If treasure map, only gather if we have none or the allowance is up.
-                .Where(item => !item.IsTreasureMap || InventoryCount(item) == 0 && NextTreasureMapAllowance < AdjustedServerTime.DateTime)
+                .Where(item => !item.IsTreasureMap || item.GetInventoryCount() == 0 && NextTreasureMapAllowance < AdjustedServerTime.DateTime)
                 // Choose the best location and calculate the next uptime.
                 .Select(GetBestLocation)
                 // Filter out items that are not available right now or don't have an unvisited location.
@@ -270,9 +271,6 @@ namespace GatherBuddy.AutoGather
                 return true;
             }
         }
-
-        private int InventoryCount(IGatherable gatherable)
-            => _plugin.AutoGatherListsManager.GetInventoryCountForItem(gatherable);
 
         private uint QuantityTotal(IGatherable gatherable)
             => _plugin.AutoGatherListsManager.GetTotalQuantitiesForItem(gatherable);

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -156,19 +156,8 @@ namespace GatherBuddy.AutoGather
             {
                 GatherTarget gatherTarget;
                 if (!_activeItemList.IsInitialized)
-                {
-                    // We can't detect what item is being gathered from inside the GatheringMasterpiece addon, so we need to reopen it.
-                    unsafe
-                    {
-                        if (MasterpieceAddon != null)
-                        {
-                            CloseGatheringAddons(false);
-                            return;
-                        }
-                    }
                     // If Auto-Gather is enabled after opening the node, the active item list is not initialized.
                     gatherTarget = _activeItemList.GetNextOrDefault();
-                }
                 else
                     // Otherwise, we don't want the list to suddenly change while gathering.
                     gatherTarget = _activeItemList.CurrentOrDefault;
@@ -213,6 +202,7 @@ namespace GatherBuddy.AutoGather
             }
 
             ActionSequence = null;
+            CurrentCollectableRotation = null;
 
             //Cache IPC call results
             var isPathGenerating = IsPathGenerating;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -66,7 +66,7 @@ namespace GatherBuddy.AutoGather
                 }
                 else
                 {
-                    RefreshNextTreasureMapAllowance();                    
+                    DiscipleOfLand.RefreshNextTreasureMapAllowance();                    
                     WentHome = true; //Prevents going home right after enabling auto-gather
                 }
 
@@ -120,6 +120,14 @@ namespace GatherBuddy.AutoGather
             if (TaskManager.IsBusy)
             {
                 //GatherBuddy.Log.Verbose("TaskManager has tasks, skipping DoAutoGather");
+                return;
+            }
+
+            if (DiscipleOfLand.NextTreasureMapAllowance == DateTime.MinValue)
+            {
+                //Wait for timer refresh
+                AutoStatus = "Refreshing timers...";
+                DiscipleOfLand.RefreshNextTreasureMapAllowance();
                 return;
             }
 
@@ -249,13 +257,6 @@ namespace GatherBuddy.AutoGather
                     AutoStatus = "No available items to gather";
                     return;
                 }
-
-            if (next.Item.IsTreasureMap && DiscipleOfLand.NextTreasureMapAllowance == DateTime.MinValue)
-            {
-                //Wait for timer refresh
-                RefreshNextTreasureMapAllowance();
-                return;
-            }
 
             if (next.Item.ItemData.IsCollectable && !CheckCollectablesUnlocked(next.Item.GatheringType.ToGroup()))
             {
@@ -488,14 +489,6 @@ namespace GatherBuddy.AutoGather
 
                     return !IsGathering;       
                 }, "Wait until Gathering addon is closed or SelectYesno addon pops up");
-            }
-        }
-
-        private static unsafe void RefreshNextTreasureMapAllowance()
-        {
-            if (EzThrottler.Throttle("RequestResetTimestamps", 1000))
-            {
-                FFXIVClientStructs.FFXIV.Client.Game.UI.UIState.Instance()->RequestResetTimestamps();
             }
         }
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -198,7 +198,7 @@ namespace GatherBuddy.AutoGather
                 StopNavigation();
                 try
                 {
-                    DoActionTasks(gatherTarget == default ? null : gatherTarget.Item);
+                    DoActionTasks(gatherTarget);
                 }
                 catch (NoGatherableItemsInNodeException)
                 {

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -505,6 +505,7 @@ namespace GatherBuddy.AutoGather
             {
                 GatheringType.Miner => DiscipleOfLand.MinerLevel,
                 GatheringType.Botanist => DiscipleOfLand.BotanistLevel,
+                GatheringType.Multiple => Math.Max(DiscipleOfLand.MinerLevel, DiscipleOfLand.BotanistLevel),
                 _ => 0
             };
             if (level < Actions.Collect.MinLevel)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -128,9 +128,6 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (CheckForLingeringMasterpieceAddon())
-                return;
-
             if (FreeInventorySlots == 0)
             {
                 AbortAutoGather("Inventory is full");
@@ -571,53 +568,6 @@ namespace GatherBuddy.AutoGather
             Chat.Instance.ExecuteCommand($"/gearset change \"{set}\"");
             TaskManager.DelayNext(Random.Shared.Next(500, 1500));  //Add a random delay to be less suspicious 
             return true;
-        }
-
-        private bool CheckForLingeringMasterpieceAddon()
-        {
-            if (IsMasterpieceOK())
-                return false;
-
-            GatherBuddy.Log.Warning("Lingering GatheringMasterpiece addon may have been detected, rechecking in one second.");
-
-            //Check again in a second to reduce the probability of false positives due to lags or race conditions.
-            TaskManager.DelayNext(1000);
-            TaskManager.Enqueue(() =>
-            {
-                if (IsMasterpieceOK())
-                    return;
-
-                GatherBuddy.Log.Error("Lingering GatheringMasterpiece addon detected.");
-                Communicator.PrintError("Your game client is in an erroneous state: the GatheringMasterpiece addon (collectable window) is left lingering in the memory " +
-                    "after the end of the gathering session. This may be due to a bug in some plugin, Dalamud, or the game itself. Gathering a collectable will crash your game. " +
-                    "You may need to restart it.");
-                if (GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon)
-                {
-                    Communicator.PrintError("Attempting to force close GatheringMasterpiece addon.");
-                    GatherBuddy.Log.Warning("Attempting to force close GatheringMasterpiece addon.");
-                    unsafe { MasterpieceAddon->Close(true); }
-                    TaskManager.DelayNext(1000);//It persists for a few framework updates, so we wait.
-                }
-                else
-                {
-                    Communicator.PrintError("Alternatively, you can try enabling the \"Force close lingering GatheringMasterpiece addon\" option under Auto-Gather > Advanced.");
-                    Enabled = false;
-                    AutoStatus = "Error";
-                }
-            });
-            return true;
-
-            unsafe bool IsMasterpieceOK()
-            {
-                if (MasterpieceAddon == null)
-                    return true;
-
-                var gathering = GatheringAddon;
-                if (IsGathering && (gathering == null || !gathering->IsVisible))
-                    return true;
-
-                return false;
-            }
         }
 
         private unsafe bool HasBrokenGear()

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -510,8 +510,8 @@ namespace GatherBuddy.AutoGather
         {
             var level = gatheringType switch
             {
-                GatheringType.Miner => GetMinerLevel(),
-                GatheringType.Botanist => GetBotanistLevel(),
+                GatheringType.Miner => DiscipleOfLand.MinerLevel,
+                GatheringType.Botanist => DiscipleOfLand.BotanistLevel,
                 _ => 0
             };
             if (level < Actions.Collect.MinLevel)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -232,14 +232,16 @@ namespace GatherBuddy.AutoGather
                 return;
 
             } else {
-
+                var next = ItemsToGather[0];
                 if (targetInfo == default
                     || targetInfo.Time.End < AdjustedServerTime
+                    || targetInfo.Time == TimeInterval.Always && next.Time != TimeInterval.Always
+                    || targetInfo.Location.Territory != next.Location.Territory
                     || !ItemsToGather.Any(x => x.Item == targetInfo.Item)
                     || VisitedTimedLocations.ContainsKey(targetInfo.Location))
                 {
                     // If we have a target selected, change it only if it's no longer in the list, expired, or visited
-                    targetInfo = ItemsToGather[0];
+                    targetInfo = next;
                     FarNodesSeenSoFar.Clear();
                     VisitedNodes.Clear();
                     GatherBuddy.Log.Debug($"New target item: {targetInfo.Item.Name} in {targetInfo.Location.Territory.Name}.{(targetInfo.Time != TimeInterval.Always

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -74,7 +74,7 @@ namespace GatherBuddy.AutoGather
                 }
 
                 _enabled = value;
-                _plugin.Ipc.AutoGatherEnabledChanged(value);
+                _plugin.Ipc.AutoGatherEnabledChanged?.Invoke(value);
             }
         }
 
@@ -277,7 +277,7 @@ namespace GatherBuddy.AutoGather
                 if (!Waiting)
                 {
                     Waiting = true;
-                    _plugin.Ipc.AutoGatherWaiting();
+                    _plugin.Ipc.AutoGatherWaiting?.Invoke();
                 }
                 AutoStatus = "No available items to gather";
                 return;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -23,6 +23,7 @@ using GatherBuddy.Data;
 using NodeType = GatherBuddy.Enums.NodeType;
 using ECommons.UIHelpers.AddonMasterImplementations;
 using GatherBuddy.Time;
+using GatherBuddy.AutoGather.Extensions;
 
 namespace GatherBuddy.AutoGather
 {
@@ -219,7 +220,7 @@ namespace GatherBuddy.AutoGather
 
             if (ItemsToGather.Count == 0)
             {
-                if (!_plugin.AutoGatherListsManager.ActiveItems.Any(i => InventoryCount(i) < QuantityTotal(i) && !(i.IsTreasureMap && InventoryCount(i) != 0)))
+                if (!_plugin.AutoGatherListsManager.ActiveItems.Any(i => i.GetInventoryCount() < QuantityTotal(i) && !(i.IsTreasureMap && i.GetInventoryCount() != 0)))
                 {
                     AbortAutoGather();
                     return;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -74,7 +74,7 @@ namespace GatherBuddy.AutoGather
                 }
 
                 _enabled = value;
-                _plugin.Ipc.AutoGatherEnabledChanged?.Invoke(value);
+                _plugin.Ipc.AutoGatherEnabledChanged(value);
             }
         }
 
@@ -277,7 +277,7 @@ namespace GatherBuddy.AutoGather
                 if (!Waiting)
                 {
                     Waiting = true;
-                    _plugin.Ipc.AutoGatherWaiting?.Invoke();
+                    _plugin.Ipc.AutoGatherWaiting();
                 }
                 AutoStatus = "No available items to gather";
                 return;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -22,6 +22,7 @@ using GatherBuddy.Data;
 using NodeType = GatherBuddy.Enums.NodeType;
 using ECommons.UIHelpers.AddonMasterImplementations;
 using GatherBuddy.AutoGather.Lists;
+using System.Collections.Generic;
 
 namespace GatherBuddy.AutoGather
 {
@@ -164,19 +165,20 @@ namespace GatherBuddy.AutoGather
 
                 if (gatherTarget != default)
                 {
-                    _activeItemList.MarkVisited(gatherTarget);
-
                     var target = Svc.Targets.Target;
-                    if (target != null
-                        && target.ObjectKind is ObjectKind.GatheringPoint
-                        && gatherTarget.Item.NodeType is NodeType.Regular or NodeType.Ephemeral
-                        && VisitedNodes.Last?.Value != target.DataId
-                        && gatherTarget.Node?.WorldPositions.ContainsKey(target.DataId) == true)
+                    if (target != null && target.ObjectKind is ObjectKind.GatheringPoint)
                     {
-                        FarNodesSeenSoFar.Clear();
-                        VisitedNodes.AddLast(target.DataId);
-                        while (VisitedNodes.Count > (gatherTarget.Node.WorldPositions.Count <= 4 ? 2 : 4))
-                            VisitedNodes.RemoveFirst();
+                        _activeItemList.MarkVisited(target);
+
+                        if (gatherTarget.Item.NodeType is NodeType.Regular or NodeType.Ephemeral
+                            && VisitedNodes.Last?.Value != target.DataId
+                            && gatherTarget.Node?.WorldPositions.ContainsKey(target.DataId) == true)
+                        {
+                            FarNodesSeenSoFar.Clear();
+                            VisitedNodes.AddLast(target.DataId);
+                            while (VisitedNodes.Count > (gatherTarget.Node.WorldPositions.Count <= 4 ? 2 : 4))
+                                VisitedNodes.RemoveFirst();
+                        }
                     }
                 } 
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -268,14 +268,6 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (!LocationMatchesJob(targetInfo.Location))
-            {
-                if (!ChangeGearSet(targetInfo.Location.GatheringType.ToGroup()))
-                    AbortAutoGather();
-
-                return;
-            }
-
             if (HasBrokenGear())
             {
                 Communicator.PrintError("Your gear is almost broken. Repair it before enabling Auto-Gather.");
@@ -338,6 +330,14 @@ namespace GatherBuddy.AutoGather
 
                 // Reset target to pick up closest item after teleport
                 targetInfo = default;
+
+                return;
+            }
+
+            if (!LocationMatchesJob(targetInfo.Location))
+            {
+                if (!ChangeGearSet(targetInfo.Location.GatheringType.ToGroup()))
+                    AbortAutoGather();
 
                 return;
             }

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -60,8 +60,8 @@ namespace GatherBuddy.AutoGather
                 if (!value)
                 {
                     TaskManager.Abort();
-                    if (VNavmesh_IPCSubscriber.IsEnabled && IsPathGenerating) 
-                        VNavmesh_IPCSubscriber.Nav_PathfindCancelAll();
+                    if (VNavmesh.Enabled && IsPathGenerating) 
+                        VNavmesh.Nav.PathfindCancelAll();
                     StopNavigation();
                     AutoStatus = "Idle...";
                     ActionSequence = null;
@@ -88,10 +88,10 @@ namespace GatherBuddy.AutoGather
             if (Dalamud.Conditions[ConditionFlag.BoundByDuty])
                 return false;
 
-            if (Lifestream_IPCSubscriber.IsEnabled && !Lifestream_IPCSubscriber.IsBusy())
+            if (Lifestream.Enabled && !Lifestream.IsBusy())
             {
-                Lifestream_IPCSubscriber.ExecuteCommand("auto");
-                TaskManager.EnqueueImmediate(() => !Lifestream_IPCSubscriber.IsBusy(), 120000, "Wait until Lifestream is done");
+                Lifestream.ExecuteCommand("auto");
+                TaskManager.EnqueueImmediate(() => !Lifestream.IsBusy(), 120000, "Wait until Lifestream is done");
                 return true;
             }
             else
@@ -299,7 +299,7 @@ namespace GatherBuddy.AutoGather
 
             var territoryId = Svc.ClientState.TerritoryType;
             //Idyllshire to The Dravanian Hinterlands
-            if (territoryId == 478 && next.Node.Territory.Id == 399 && Lifestream_IPCSubscriber.IsEnabled)
+            if (territoryId == 478 && next.Node.Territory.Id == 399 && Lifestream.Enabled)
             {
                 var aetheryte = Svc.Objects.Where(x => x.ObjectKind == ObjectKind.Aetheryte && x.IsTargetable).OrderBy(x => x.Position.DistanceToPlayer()).FirstOrDefault();
                 if (aetheryte != null)
@@ -309,13 +309,13 @@ namespace GatherBuddy.AutoGather
                         AutoStatus = "Moving to aetheryte...";
                         if (!isPathing && !isPathGenerating) Navigate(aetheryte.Position, false);
                     }
-                    else if (!Lifestream_IPCSubscriber.IsBusy())
+                    else if (!Lifestream.IsBusy())
                     {
                         AutoStatus = "Teleporting...";
                         StopNavigation();
                         var exit = next.Node.DefaultXCoord < 2000 ? 91u : 92u;
                         var name = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.Aetheryte>().GetRow(exit).AethernetName.Value.Name.ToString();
-                        Lifestream_IPCSubscriber.AethernetTeleport(name);
+                        Lifestream.AethernetTeleport(name);
                     }
                     return;
                 }
@@ -326,7 +326,7 @@ namespace GatherBuddy.AutoGather
                 && (GatherBuddy.GameData.Aetherytes[forcedAetheryte.AetheryteId].Territory.Id == territoryId
                 || forcedAetheryte.AetheryteId == 70 && territoryId == 886)) //The Firmament
             {
-                if (territoryId == 478 && !Lifestream_IPCSubscriber.IsEnabled)
+                if (territoryId == 478 && !Lifestream.Enabled)
                     AutoStatus = $"Install Lifestream or teleport to {next.Node.Territory.Name} manually";
                 else
                     AutoStatus = "Manual teleporting required";
@@ -334,7 +334,7 @@ namespace GatherBuddy.AutoGather
             }
 
             //At this point, we are definitely going to gather something, so we may go home after that.
-            if (Lifestream_IPCSubscriber.IsEnabled) Lifestream_IPCSubscriber.Abort();
+            if (Lifestream.Enabled) Lifestream.Abort();
             WentHome = false;
 
             if (next.Node.Territory.Id != territoryId)
@@ -445,7 +445,7 @@ namespace GatherBuddy.AutoGather
                     .OrderBy(o => Vector2.Distance(pos.Value, new Vector2(o.X, o.Z)))
                     .FirstOrDefault();
                 if (selectedFarNode == default)
-                    selectedFarNode = VNavmesh_IPCSubscriber.Query_Mesh_NearestPoint(new Vector3(pos.Value.X, 0, pos.Value.Y), 10, 10000);
+                    selectedFarNode = VNavmesh.Query.Mesh.NearestPoint(new Vector3(pos.Value.X, 0, pos.Value.Y), 10, 10000);
             }
             else
             {

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -22,7 +22,6 @@ using GatherBuddy.Data;
 using NodeType = GatherBuddy.Enums.NodeType;
 using ECommons.UIHelpers.AddonMasterImplementations;
 using GatherBuddy.AutoGather.Lists;
-using System.Collections.Generic;
 
 namespace GatherBuddy.AutoGather
 {
@@ -605,6 +604,11 @@ namespace GatherBuddy.AutoGather
         internal void DebugClearVisited()
         {
             _activeItemList.DebugClearVisited();
+        }
+
+        internal void DebugMarkVisited(GatherTarget target)
+        {
+            _activeItemList.DebugMarkVisited(target);
         }
 
         public void Dispose()

--- a/GatherBuddy/AutoGather/ConfigPreset.cs
+++ b/GatherBuddy/AutoGather/ConfigPreset.cs
@@ -30,6 +30,7 @@ namespace GatherBuddy.AutoGather
         public int CollectableMinGP { get => collectableMinGP; set => collectableMinGP = Math.Max(0, Math.Min(MaxGP, value)); }
         public int CollectableActionsMinGP { get => collectableActionsMinGP; set => collectableActionsMinGP = Math.Max(0, Math.Min(MaxGP, value)); }
         public bool CollectableAlwaysUseSolidAge { get; set; } = true;
+        public bool CollectableManualScores { get; set; } = false;
         public int CollectableTagetScore { get => collectableTagetScore; set => collectableTagetScore = Math.Max(0, Math.Min(MaxCollectability, value)); }
         public int CollectableMinScore { get => collectableMinScore; set => collectableMinScore = Math.Max(0, Math.Min(MaxCollectability, value)); }
         public bool ChooseBestActionsAutomatically { get; set; } = false;

--- a/GatherBuddy/AutoGather/Extensions/GatherableExtensions.cs
+++ b/GatherBuddy/AutoGather/Extensions/GatherableExtensions.cs
@@ -1,0 +1,21 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
+using GatherBuddy.Interfaces;
+
+namespace GatherBuddy.AutoGather.Extensions;
+
+/// <summary>
+/// Extension methods for the IGatherable interface.
+/// </summary>
+public static class GatherableExtensions
+{
+    /// <summary>
+    /// Gets the inventory count for a gatherable item.
+    /// </summary>
+    /// <param name="gatherable">The gatherable item to check.</param>
+    /// <returns>The count of the item in the inventory.</returns>
+    public unsafe static int GetInventoryCount(this IGatherable gatherable)
+    {
+        var inventory = InventoryManager.Instance();
+        return inventory->GetInventoryItemCount(gatherable.ItemId, false, false, false, (short)(gatherable.ItemData.IsCollectable ? 1 : 0));
+    }
+}

--- a/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
+++ b/GatherBuddy/AutoGather/Helpers/AdvancedUnstuck.cs
@@ -1,9 +1,8 @@
 ﻿using Dalamud.Plugin.Services;
-using ECommons.Automation.LegacyTaskManager;
 using ECommons.GameHelpers;
+using ECommons.MathHelpers;
 using GatherBuddy.CustomInfo;
 using System;
-using System.Diagnostics;
 using System.Numerics;
 
 namespace GatherBuddy.AutoGather.Movement
@@ -39,7 +38,7 @@ namespace GatherBuddy.AutoGather.Movement
             //On cooldown, not navigating or near the destination: disable tracking and reset
             if (now.Subtract(_unstuckStart).TotalSeconds < GatherBuddy.Config.AutoGatherConfig.NavResetCooldown
                 || destination == default
-                || destination.DistanceToPlayer() < 3)
+                || Vector2.Distance(destination.ToVector2(), Player.Position.ToVector2()) < 3.5)
             {
                 _lastCheck = DateTime.MinValue;
                 return AdvancedUnstuckCheckResult.Pass;

--- a/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
+++ b/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
@@ -1,0 +1,16 @@
+using ECommons.ExcelServices;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+
+namespace GatherBuddy.AutoGather
+{
+    public static class DiscipleOfLand
+    {
+        private static readonly sbyte _minerExpArrayIndex = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.MIN).ExpArrayIndex;
+        private static readonly sbyte _botanistExpArrayIndex = Dalamud.GameData.GetExcelSheet<Lumina.Excel.Sheets.ClassJob>().GetRow((uint)Job.BTN).ExpArrayIndex;
+
+        public static unsafe int MinerLevel => PlayerState.Instance()->ClassJobLevels[_minerExpArrayIndex];
+        public static unsafe int BotanistLevel => PlayerState.Instance()->ClassJobLevels[_botanistExpArrayIndex];
+        public static unsafe int Gathering => PlayerState.Instance()->Attributes[72];
+        public static unsafe int Perception => PlayerState.Instance()->Attributes[73];
+    }
+}

--- a/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
+++ b/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
@@ -1,4 +1,5 @@
 using ECommons.ExcelServices;
+using ECommons.Throttlers;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using System;
 
@@ -14,6 +15,14 @@ namespace GatherBuddy.AutoGather
         public static unsafe int Gathering => PlayerState.Instance()->Attributes[72];
         public static unsafe int Perception => PlayerState.Instance()->Attributes[73];
         public static unsafe DateTime NextTreasureMapAllowance => UIState.Instance()->GetNextMapAllowanceDateTime();
+
+        public static unsafe void RefreshNextTreasureMapAllowance()
+        {
+            if (EzThrottler.Throttle("RequestResetTimestamps", 1000))
+            {
+                UIState.Instance()->RequestResetTimestamps();
+            }
+        }
 
     }
 }

--- a/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
+++ b/GatherBuddy/AutoGather/Helpers/DiscipleOfLand.cs
@@ -1,5 +1,6 @@
 using ECommons.ExcelServices;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using System;
 
 namespace GatherBuddy.AutoGather
 {
@@ -12,5 +13,7 @@ namespace GatherBuddy.AutoGather
         public static unsafe int BotanistLevel => PlayerState.Instance()->ClassJobLevels[_botanistExpArrayIndex];
         public static unsafe int Gathering => PlayerState.Instance()->Attributes[72];
         public static unsafe int Perception => PlayerState.Instance()->Attributes[73];
+        public static unsafe DateTime NextTreasureMapAllowance => UIState.Instance()->GetNextMapAllowanceDateTime();
+
     }
 }

--- a/GatherBuddy/AutoGather/Helpers/RotationSolver.cs
+++ b/GatherBuddy/AutoGather/Helpers/RotationSolver.cs
@@ -10,7 +10,6 @@ using Actions = GatherBuddy.AutoGather.AutoGather.Actions;
 using ItemSlot = GatherBuddy.AutoGather.GatheringTracker.ItemSlot;
 using ECommons.ExcelServices;
 using ECommons;
-using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using GatherBuddy.CustomInfo;
 
 namespace GatherBuddy.AutoGather.Helpers
@@ -519,7 +518,7 @@ namespace GatherBuddy.AutoGather.Helpers
             var basePerception = WorldData.IlvConvertTable[(int)glvl].BasePerception;
             if (basePerception == 0) return 0;
 
-            var score = (uint)Math.Min(150, 100 * CharacterPerceptionStat / basePerception);
+            var score = (uint)Math.Min(150, 100 * DiscipleOfLand.Perception / basePerception);
             if (score >= 100) return (score - 100) * (60 - 35) / (150 - 100) + 35;
             if (score >=  80) return (score -  80) * (35 - 15) / (100 -  80) + 15;
             if (score >=  70) return (score -  70) * (15 - 10) / ( 80 -  70) + 10;
@@ -527,7 +526,5 @@ namespace GatherBuddy.AutoGather.Helpers
 
             return 0;
         }
-
-        private static unsafe int CharacterPerceptionStat => PlayerState.Instance()->Attributes[73];
     }
 }

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -1,0 +1,349 @@
+﻿using Dalamud.Utility;
+using ECommons;
+using ECommons.GameHelpers;
+using FFXIVClientStructs.FFXIV.Client.Game.UI;
+using GatherBuddy.AutoGather.Extensions;
+using GatherBuddy.Classes;
+using GatherBuddy.Config;
+using GatherBuddy.Enums;
+using GatherBuddy.Time;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Numerics;
+
+namespace GatherBuddy.AutoGather.Lists
+{
+    internal class ActiveItemList : IEnumerable<GatherTarget>, IDisposable
+    {
+        private readonly List<GatherTarget> _gatherableItems = [];
+        private readonly Dictionary<uint, uint> _allItemsIds = [];
+        private readonly AutoGatherListsManager _listsManager;
+        private readonly Dictionary<uint, uint> _teleportationCosts = [];
+        private readonly Dictionary<GatheringNode, TimeInterval> _visitedTimedNodes = [];
+        private TimeStamp _lastUpdateTime;
+        private uint _lastTerritoryId;
+        private bool _activeItemsChanged;
+        private bool _gatheredSomething;
+
+        internal ReadOnlyDictionary<GatheringNode, TimeInterval> DebugVisitedTimedLocations => _visitedTimedNodes.AsReadOnly();
+
+        /// <summary>
+        /// First item on the list as of the last enumeration or default.
+        /// </summary>
+        public GatherTarget CurrentOrDefault => _gatherableItems.FirstOrDefault();
+
+        /// <summary>
+        /// Determines whether there are any items that need to be gathered,
+        /// including items that are not up yet.
+        /// </summary>
+        /// <value>
+        /// True if there are items that need to be gathered; otherwise, false.
+        /// </value>
+        public bool HasItemsToGather => _listsManager.ActiveItems.Where(NeedsGathering).Any();
+
+        public bool IsInitialized => _lastUpdateTime != TimeStamp.MinValue;
+
+        public ActiveItemList(AutoGatherListsManager listsManager)
+        {
+            _listsManager = listsManager;
+            _listsManager.ActiveItemsChanged += OnActiveItemsChanged;
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the available gather targets.
+        /// </summary>
+        /// <returns>
+        /// An enumerator for the available gather targets.
+        /// </returns>
+        public IEnumerator<GatherTarget> GetEnumerator()
+        {
+            return _gatherableItems.GetEnumerator();
+        }
+
+        /// <summary>
+        /// Refreshes the list of items to gather (if needed) and returns the first item.
+        /// </summary>
+        /// <returns>The next item to gather. </returns>
+        public GatherTarget GetNextOrDefault()
+        {
+            if (IsUpdateNeeded())
+                DoUpdate();
+
+            return this.FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Marks a node as visited.
+        /// </summary>
+        /// <param name="info">The GatherTarget containing the node to mark as visited.</param>
+        public void MarkVisited(GatherTarget info)
+        {
+            _gatheredSomething = true;
+            if (info.Time != TimeInterval.Always && info.Node.NodeType is NodeType.Legendary or NodeType.Unspoiled)
+                _visitedTimedNodes[info.Node] = info.Time;
+        }
+
+        /// <summary>
+        /// Determines whether the auto-gather list contains the specified item and it needs gathering.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns>True if the item is in the list and needs gathering; otherwise, false.</returns>
+        public bool Contains(Gatherable item)
+        {
+            return _allItemsIds.TryGetValue(item.ItemId, out var quantity) && 
+                   item.GetInventoryCount() < (item.IsTreasureMap ? 1 : quantity);
+        }
+
+        private bool NeedsGathering((Gatherable item, uint quantity) value)
+        {
+            var (item, quantity) = value;
+            return item.GetInventoryCount() < (item.IsTreasureMap ? 1 : quantity);
+        }
+
+        private bool NeedsGathering(GatherTarget target) => NeedsGathering((target.Item, target.Quantity));
+
+
+        private void OnActiveItemsChanged()
+        {
+            _activeItemsChanged = true;
+        }
+
+        private void RemoveExpiredVisited(TimeStamp adjustedServerTime)
+        {
+            foreach (var (loc, time) in _visitedTimedNodes)
+                if (time.End < adjustedServerTime)
+                    _visitedTimedNodes.Remove(loc);
+        }
+
+        internal void DebugClearVisited()
+        {
+            _visitedTimedNodes.Clear();
+        }
+
+        /// <summary>
+        /// Updates the list of items to gather based on the current territory and player levels.
+        /// </summary>
+        /// <param name="territoryId">The ID of the current territory.</param>
+        private void UpdateItemsToGather(uint territoryId)
+        {
+            // Items are unlocked in tiers of 5 levels, so we round up to the nearest 5.
+            var minerLevel = (DiscipleOfLand.MinerLevel + 4) / 5 * 5;
+            var botanistLevel = (DiscipleOfLand.BotanistLevel + 4) / 5 * 5;
+            var adjustedServerTime = _lastUpdateTime;
+
+            var nodes = _listsManager.ActiveItems
+                // Filter out items that are already gathered.
+                .Where(NeedsGathering)
+                // If treasure map, only gather if the allowance is up.
+                .Where(x => !x.Item.IsTreasureMap || DiscipleOfLand.NextTreasureMapAllowance < adjustedServerTime.DateTime)
+                // Record original item order and fetch preferred location.
+                .Select((x, Index) => (x.Item, x.Quantity, Index, PreferredLocation: _listsManager.GetPreferredLocation(x.Item)))
+                // Flatten node list add calculate the next uptime.
+                .SelectMany(x => x.Item.NodeList.Select(Node => (x.Item, Node, Time: Node.Times.NextUptime(adjustedServerTime), x.Quantity, x.Index, x.PreferredLocation)))
+                // Remove nodes with a level higher than the player can gather.
+                .Where(info => info.Node.GatheringType.ToGroup() switch
+                {
+                    GatheringType.Miner => info.Node.Level <= minerLevel,
+                    GatheringType.Botanist => info.Node.Level <= botanistLevel,
+                    _ => false
+                })
+                // Remove nodes that are not up.
+                .Where(x => x.Time.InRange(adjustedServerTime))
+                // Remove nodes that are already gathered.
+                .Where(x => !_visitedTimedNodes.ContainsKey(x.Node))
+                // Prioritize timed nodes first.
+                .OrderBy(x => x.Time == TimeInterval.Always);
+
+            if (GatherBuddy.Config.AutoGatherConfig.SortingMethod == AutoGatherConfig.SortingType.Location)
+            {
+                nodes = nodes
+                    // Order by node type.
+                    .ThenBy(x => GetNodeTypeAsPriority(x.Item))
+                    // Then by teleportation cost.
+                    .ThenBy(x => x.Node.Territory.Id == territoryId ? 0 : GetTeleportationCost(x.Node))
+                    // Then by distance to the player (for current territory).
+                    .ThenBy(x => GetHorizontalSquaredDistanceToPlayer(x.Node));
+            }
+
+            nodes = nodes
+                // Fix item order, so following sorts are only applied to nodes of the same item.
+                .ThenBy(x => x.Index)
+                // Prioritize preferred location, then preferred job, then the rest.
+                .ThenBy(x =>
+                      x.Node == x.PreferredLocation ? 0
+                    : x.Node.GatheringType.ToGroup() == GatherBuddy.Config.PreferredGatheringType ? 1
+                    : 2)
+                // Prioritize closest nodes in the current territory (in case of not sorting by location).
+                .ThenBy(x => GetHorizontalSquaredDistanceToPlayer(x.Node))
+                // Order by end time, longest first as in the original UptimeManager.NextUptime().
+                .ThenByDescending(info => info.Time.End);
+            ;
+
+            switch (GatherBuddy.Config.AetherytePreference)
+            {
+                case AetherytePreference.Distance:
+                    nodes = nodes
+                        // Order by distance to the closest aetheryte.
+                        .ThenBy(info => AutoGather.FindClosestAetheryte(info.Node)?
+                            .WorldDistance(info.Node.Territory.Id, info.Node.IntegralXCoord, info.Node.IntegralYCoord)
+                            ?? int.MaxValue);
+                    break;
+                case AetherytePreference.Cost:
+                    nodes = nodes
+                        // Order by teleportation cost.
+                        .ThenBy(info => GetTeleportationCost(info.Node));
+                    break;
+            }
+
+            _gatherableItems.Clear();
+            _allItemsIds.Clear();
+            _gatherableItems.AddRange(nodes.Select(x => new GatherTarget(x.Item, x.Node, x.Time, x.Quantity)));
+            foreach (var x in _gatherableItems)
+                _allItemsIds[x.Item.ItemId] = x.Quantity;
+        }
+
+        private static float GetHorizontalSquaredDistanceToPlayer(GatheringNode node)
+        {
+            if (node.Territory.Id != Dalamud.ClientState.TerritoryType)
+                return float.MaxValue;
+
+            // Node coordinates are map coordinates multiplied by 100.
+            var playerPos3D = Player.Object.GetMapCoordinates();
+            var playerPos = new Vector2(playerPos3D.X * 100f, playerPos3D.Y * 100f);
+            return Vector2.DistanceSquared(new Vector2(node.IntegralXCoord, node.IntegralYCoord), playerPos);
+        }
+
+        /// <summary>
+        /// For sorting items in the following order: Legendary, Unspoiled, Ephemeral, Regular.
+        /// </summary>
+        private static int GetNodeTypeAsPriority(Gatherable item)
+        {
+            return item.NodeType switch
+            {
+                NodeType.Legendary => 0,
+                NodeType.Unspoiled => 1,
+                NodeType.Ephemeral => 2,
+                NodeType.Regular => 9,
+                _ => 99,
+            };
+        }
+
+        private uint GetTeleportationCost(GatheringNode location)
+        {
+            var aetheryte = AutoGather.FindClosestAetheryte(location);
+            if (aetheryte == null)
+                return uint.MaxValue; // If there's no aetheryte, put it at the end
+
+            return _teleportationCosts.GetValueOrDefault(aetheryte.Id, uint.MaxValue);
+        }
+
+        /// <summary>
+        /// Stores teleportation costs in the dictionary.
+        /// </summary>
+        private unsafe void UpdateTeleportationCosts()
+        {
+            _teleportationCosts.Clear();
+
+            var telepo = Telepo.Instance();
+            if (telepo == null) return;
+
+            telepo->UpdateAetheryteList();
+            _teleportationCosts.EnsureCapacity(telepo->TeleportList.Count);
+
+            for (var i = 0; i < telepo->TeleportList.Count; i++)
+            {
+                var entry = telepo->TeleportList[i];
+                _teleportationCosts[entry.AetheryteId] = entry.GilCost;
+            }
+        }
+
+        /// <summary>
+        /// Returns true in the following cases:
+        /// 1) The active item list has changed.
+        /// 2) The Eorzea hour has changed.
+        /// 3) The territory has changed.
+        /// 4) The player has gathered enough of an item or it can no longer be gathered in the current territory.
+        /// </summary>
+        /// <returns>
+        /// True if an update is needed; otherwise, false.
+        /// </returns>
+        private bool IsUpdateNeeded()
+        {
+            if (_activeItemsChanged
+                || _lastUpdateTime.TotalEorzeaHours() != AutoGather.AdjustedServerTime.TotalEorzeaHours()
+                || _lastTerritoryId != Dalamud.ClientState.TerritoryType)
+                return true;
+
+            if (_gatheredSomething)
+            {
+                _gatheredSomething = false;
+                var current = CurrentOrDefault;
+                foreach (var item in _gatherableItems.Where(NeedsGathering).Where(x => !_visitedTimedNodes.ContainsKey(x.Node)))
+                {
+                    if (item == current)
+                        return false;
+                    if (item.Node.Territory.Id != _lastTerritoryId)
+                        break;
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Updates the active item list, teleportation costs, and clears expired visited nodes.
+        /// </summary>
+        private void DoUpdate()
+        {
+            var territoryId = Dalamud.ClientState.TerritoryType;
+            var adjustedServerTime = AutoGather.AdjustedServerTime;
+            var eorzeaHour = adjustedServerTime.TotalEorzeaHours();
+            var lastTerritoryId = _lastTerritoryId;
+            var lastEorzeaHour = adjustedServerTime.TotalEorzeaHours();
+
+            _activeItemsChanged = false;
+            _gatheredSomething = false;
+            _lastUpdateTime = adjustedServerTime;
+            _lastTerritoryId = territoryId;
+
+            if (territoryId != lastTerritoryId)
+                UpdateTeleportationCosts();
+
+            if (eorzeaHour != lastEorzeaHour)
+                RemoveExpiredVisited(adjustedServerTime);
+
+            UpdateItemsToGather(territoryId);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+
+        internal void Reset()
+        {
+            _lastTerritoryId = 0;
+            _lastUpdateTime = TimeStamp.MinValue;
+            _gatherableItems.Clear();
+            _gatherableItems.TrimExcess();
+            _visitedTimedNodes.Clear();
+            _visitedTimedNodes.TrimExcess();
+            _teleportationCosts.Clear();
+            _teleportationCosts.TrimExcess();
+        }
+
+        public void Dispose()
+        {
+            if (_listsManager != null)
+            {
+                _listsManager.ActiveItemsChanged -= OnActiveItemsChanged;
+            }
+        }
+    }
+    public record struct GatherTarget(Gatherable Item, GatheringNode Node, TimeInterval Time, uint Quantity) { }
+}

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -148,7 +148,7 @@ namespace GatherBuddy.AutoGather.Lists
                           x.Node == x.PreferredLocation ? 0
                         : x.Node.GatheringType.ToGroup() == GatherBuddy.Config.PreferredGatheringType ? 1
                         : 2)
-                    // Prioritize closest nodes in the current territory (in case of not sorting by location).
+                    // Prioritize closest nodes in the current territory.
                     .ThenBy(x => GetHorizontalSquaredDistanceToPlayer(x.Node))
                     // Order by end time, longest first as in the original UptimeManager.NextUptime().
                     .ThenByDescending(x => x.Time.End)

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -111,7 +111,7 @@ namespace GatherBuddy.AutoGather.Lists
         private void RemoveExpiredVisited(TimeStamp adjustedServerTime)
         {
             foreach (var (loc, time) in _visitedTimedNodes)
-                if (time.End < adjustedServerTime)
+                if (time.End <= adjustedServerTime)
                     _visitedTimedNodes.Remove(loc);
         }
 
@@ -289,7 +289,7 @@ namespace GatherBuddy.AutoGather.Lists
             var adjustedServerTime = AutoGather.AdjustedServerTime;
             var eorzeaHour = adjustedServerTime.TotalEorzeaHours();
             var lastTerritoryId = _lastTerritoryId;
-            var lastEorzeaHour = adjustedServerTime.TotalEorzeaHours();
+            var lastEorzeaHour = _lastUpdateTime.TotalEorzeaHours();
 
             _activeItemsChanged = false;
             _gatheredSomething = false;
@@ -316,8 +316,6 @@ namespace GatherBuddy.AutoGather.Lists
             _lastUpdateTime = TimeStamp.MinValue;
             _gatherableItems.Clear();
             _gatherableItems.TrimExcess();
-            _visitedTimedNodes.Clear();
-            _visitedTimedNodes.TrimExcess();
             _teleportationCosts.Clear();
             _teleportationCosts.TrimExcess();
         }

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -1,5 +1,4 @@
 ﻿using Dalamud.Utility;
-using ECommons;
 using ECommons.GameHelpers;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using GatherBuddy.AutoGather.Extensions;
@@ -11,7 +10,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
 
@@ -20,7 +18,6 @@ namespace GatherBuddy.AutoGather.Lists
     internal class ActiveItemList : IEnumerable<GatherTarget>, IDisposable
     {
         private readonly List<GatherTarget> _gatherableItems = [];
-        private readonly Dictionary<uint, uint> _allItemsIds = [];
         private readonly AutoGatherListsManager _listsManager;
         private readonly Dictionary<uint, uint> _teleportationCosts = [];
         private readonly Dictionary<GatheringNode, TimeInterval> _visitedTimedNodes = [];
@@ -86,18 +83,6 @@ namespace GatherBuddy.AutoGather.Lists
             if (info.Time != TimeInterval.Always && info.Node.NodeType is NodeType.Legendary or NodeType.Unspoiled)
                 _visitedTimedNodes[info.Node] = info.Time;
         }
-
-        /// <summary>
-        /// Determines whether the auto-gather list contains the specified item and it needs gathering.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <returns>True if the item is in the list and needs gathering; otherwise, false.</returns>
-        public bool Contains(Gatherable item)
-        {
-            return _allItemsIds.TryGetValue(item.ItemId, out var quantity) && 
-                   item.GetInventoryCount() < (item.IsTreasureMap ? 1 : quantity);
-        }
-
         private bool NeedsGathering((Gatherable item, uint quantity) value)
         {
             var (item, quantity) = value;
@@ -200,10 +185,7 @@ namespace GatherBuddy.AutoGather.Lists
             }
 
             _gatherableItems.Clear();
-            _allItemsIds.Clear();
             _gatherableItems.AddRange(nodes.Select(x => new GatherTarget(x.Item, x.Node, x.Time, x.Quantity)));
-            foreach (var x in _gatherableItems)
-                _allItemsIds[x.Item.ItemId] = x.Quantity;
         }
 
         private static float GetHorizontalSquaredDistanceToPlayer(GatheringNode node)

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -86,6 +86,14 @@ namespace GatherBuddy.AutoGather.Lists
             if (x != default && x.Time != TimeInterval.Always && x.Node.NodeType is NodeType.Legendary or NodeType.Unspoiled)
                 _visitedTimedNodes[x.Node] = x.Time;
         }
+
+        internal void DebugMarkVisited(GatherTarget x)
+        {
+            _gatheredSomething = true;
+            if (x.Time != TimeInterval.Always && x.Node.NodeType is NodeType.Legendary or NodeType.Unspoiled)
+                _visitedTimedNodes[x.Node] = x.Time;
+        }
+
         private bool NeedsGathering((Gatherable item, uint quantity) value)
         {
             var (item, quantity) = value;

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -123,13 +123,13 @@ namespace GatherBuddy.AutoGather.Lists
         /// <summary>
         /// Updates the list of items to gather based on the current territory and player levels.
         /// </summary>
-        /// <param name="territoryId">The ID of the current territory.</param>
-        private void UpdateItemsToGather(uint territoryId)
+        private void UpdateItemsToGather()
         {
             // Items are unlocked in tiers of 5 levels, so we round up to the nearest 5.
             var minerLevel = (DiscipleOfLand.MinerLevel + 4) / 5 * 5;
             var botanistLevel = (DiscipleOfLand.BotanistLevel + 4) / 5 * 5;
             var adjustedServerTime = _lastUpdateTime;
+            var territoryId = _lastTerritoryId;
             DateTime? nextAllowance = null;
 
             var nodes = _listsManager.ActiveItems
@@ -302,7 +302,7 @@ namespace GatherBuddy.AutoGather.Lists
             if (eorzeaHour != lastEorzeaHour)
                 RemoveExpiredVisited(adjustedServerTime);
 
-            UpdateItemsToGather(territoryId);
+            UpdateItemsToGather();
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -119,12 +119,13 @@ namespace GatherBuddy.AutoGather.Lists
             var minerLevel = (DiscipleOfLand.MinerLevel + 4) / 5 * 5;
             var botanistLevel = (DiscipleOfLand.BotanistLevel + 4) / 5 * 5;
             var adjustedServerTime = _lastUpdateTime;
+            DateTime? nextAllowance = null;
 
             var nodes = _listsManager.ActiveItems
                 // Filter out items that are already gathered.
                 .Where(NeedsGathering)
                 // If treasure map, only gather if the allowance is up.
-                .Where(x => !x.Item.IsTreasureMap || DiscipleOfLand.NextTreasureMapAllowance < adjustedServerTime.DateTime)
+                .Where(x => !x.Item.IsTreasureMap || (nextAllowance ??= DiscipleOfLand.NextTreasureMapAllowance) < adjustedServerTime.DateTime)
                 // Record original item order and fetch preferred location.
                 .Select((x, Index) => (x.Item, x.Quantity, Index, PreferredLocation: _listsManager.GetPreferredLocation(x.Item)))
                 // Flatten node list add calculate the next uptime.

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -15,16 +15,18 @@ namespace GatherBuddy.AutoGather.Lists;
 
 public partial class AutoGatherListsManager : IDisposable
 {
+    public event Action? ActiveItemsChanged;
+
     private const string FileName = "auto_gather_lists.json";
     private const string FileNameFallback = "gather_window.json";
 
     private readonly List<AutoGatherList> _lists = [];
-    private readonly List<Gatherable> _activeItems = [];
+    private readonly List<(Gatherable Item, uint Quantity)> _activeItems = [];
     private readonly List<Gatherable> _sortedItems = [];
     private readonly List<(Gatherable Item, uint Quantity)> _fallbackItems = [];
 
     public ReadOnlyCollection<AutoGatherList> Lists => _lists.AsReadOnly();
-    public ReadOnlyCollection<Gatherable> ActiveItems => _activeItems.AsReadOnly();
+    public ReadOnlyCollection<(Gatherable Item, uint Quantity)> ActiveItems => _activeItems.AsReadOnly();
     public ReadOnlyCollection<(Gatherable Item, uint Quantity)> FallbackItems => _fallbackItems.AsReadOnly();
 
     private          bool         _sortDirty = true;
@@ -40,56 +42,53 @@ public partial class AutoGatherListsManager : IDisposable
     private void OnUptimeChange(IGatherable item)
         => _sortDirty = true;
 
-    private void OnActiveAlarmsChange()
-        => SetActiveItems();
-
     public void SetActiveItems()
     {
         _activeItems.Clear();
-        foreach (var item in _lists.Where(p => p.Enabled && !p.Fallback)
-                     .SelectMany(p => p.Items)
-                     .Where(i => !_activeItems.Contains(i)))
-            _activeItems.Add(item);
         _sortedItems.Clear();
-        _sortedItems.InsertRange(0, _activeItems);
-        _sortDirty = true;
-
-        var fallback = _lists
-            .Where(p => p.Enabled && p.Fallback)
-            .SelectMany(p => p.Items.Select(i => (Item: i, Quantity: p.Quantities[i])))
-            .GroupBy(i => i.Item)
-            .Select(x => (x.Key, (uint)Math.Min(x.Sum(g => g.Quantity), uint.MaxValue)));
         _fallbackItems.Clear();
-        _fallbackItems.AddRange(fallback);
+        var items = _lists
+            .Where(l => l.Enabled)
+            .SelectMany(l => l.Items.Select(i => (Item: i, Quantity: l.Quantities[i], l.Fallback)))
+            .GroupBy(i => (i.Item, i.Fallback))
+            .Select(x => (x.Key.Item, Quantity: (uint)Math.Min(x.Sum(g => g.Quantity), uint.MaxValue), x.Key.Fallback));
+        
+        foreach (var (item, quantity, fallback) in items)
+        {
+            if (fallback)
+            {
+                _fallbackItems.Add((item, quantity));
+            }
+            else
+            {
+                _activeItems.Add((item, quantity));
+                _sortedItems.Add(item);
+            }
+        }
+
+        _sortDirty = true;
+        ActiveItemsChanged?.Invoke();
     }
 
     public IReadOnlyList<Gatherable> GetList()
     {
-        if (!GatherBuddy.Config.SortGatherWindowByUptime)
-            return _activeItems;
-
-        if (_sortDirty)
+        if (_sortDirty && GatherBuddy.Config.SortGatherWindowByUptime)
+        {
             _sortedItems.StableSort((lhs, rhs)
                 => GatherBuddy.UptimeManager.BestLocation(lhs).Interval.Compare(GatherBuddy.UptimeManager.BestLocation(rhs).Interval));
+            _sortDirty = false;
+        }
 
         return _sortedItems;
     }
 
+    [Obsolete]
     public uint GetTotalQuantitiesForItem(IGatherable item)
     {
         if (item is not Gatherable gatherable)
             return 0;
 
-        uint total = 0;
-        foreach (var list in _lists)
-        {
-            if (list.Enabled && !list.Fallback && list.Quantities.TryGetValue(gatherable, out var quantity))
-            {
-                total += quantity;
-            }
-        }
-
-        return total;
+        return _activeItems.Where(x => x.Item == gatherable).Select(x => x.Quantity).FirstOrDefault();
     }
 
     public List<InventoryType> InventoryTypes

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -90,22 +90,7 @@ public partial class AutoGatherListsManager : IDisposable
 
         return _activeItems.Where(x => x.Item == gatherable).Select(x => x.Quantity).FirstOrDefault();
     }
-
-    public List<InventoryType> InventoryTypes
-    {
-        get
-        {
-            List<InventoryType> types = new List<InventoryType>()
-            {
-                InventoryType.Inventory1,
-                InventoryType.Inventory2,
-                InventoryType.Inventory3,
-                InventoryType.Inventory4,
-            };
-            return types;
-        }
-    }
-
+    
     public void Save()
     {
         var file = Functions.ObtainSaveFile(FileName);

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -92,12 +92,6 @@ public partial class AutoGatherListsManager : IDisposable
         return total;
     }
 
-    public unsafe int GetInventoryCountForItem(IGatherable gatherable)
-    {
-        var inventory = InventoryManager.Instance();
-        return inventory->GetInventoryItemCount(gatherable.ItemId, false, false, false, (short)(gatherable.ItemData.IsCollectable ? 1 : 0));
-    }
-    
     public List<InventoryType> InventoryTypes
     {
         get

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -94,33 +94,8 @@ public partial class AutoGatherListsManager : IDisposable
 
     public unsafe int GetInventoryCountForItem(IGatherable gatherable)
     {
-        if (gatherable.ItemData.IsCollectable)
-        {
-            int count   = 0;
-            var manager = InventoryManager.Instance();
-            if (manager == null)
-                return count;
-            foreach (var inv in InventoryTypes)
-            {
-                var container = manager->GetInventoryContainer(inv);
-                if (container == null || container->Loaded == 0)
-                    continue;
-                for (int i = 0; i < container->Size; i++)
-                {
-                    var item = container->GetInventorySlot(i);
-                    if (item == null || item->ItemId == 0 || item->ItemId != gatherable.ItemId) continue;
-        
-                    count++;
-                }
-            }
-        
-            return count;
-        }
-        else
-        {
-            var inventory = InventoryManager.Instance();
-            return inventory->GetInventoryItemCount(gatherable.ItemId);
-        }
+        var inventory = InventoryManager.Instance();
+        return inventory->GetInventoryItemCount(gatherable.ItemId, false, false, false, (short)(gatherable.ItemData.IsCollectable ? 1 : 0));
     }
     
     public List<InventoryType> InventoryTypes

--- a/GatherBuddy/GatherBuddy.cs
+++ b/GatherBuddy/GatherBuddy.cs
@@ -36,7 +36,7 @@ namespace GatherBuddy;
 
 public partial class GatherBuddy : IDalamudPlugin
 {
-    public const string InternalName = "GatherBuddy";
+    public const string InternalName = "GatherBuddyReborn";
 
     public string Name
         => InternalName;

--- a/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
+++ b/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
@@ -6,6 +6,7 @@ using System.Text;
 using Dalamud.Game.ClientState.Keys;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
+using GatherBuddy.AutoGather.Extensions;
 using GatherBuddy.Classes;
 using GatherBuddy.Config;
 using GatherBuddy.Gui;
@@ -117,7 +118,7 @@ public class GatherWindow : Window
         if (GatherBuddy.Config.ShowGatherWindowOnlyAvailable && time.Start > GatherBuddy.Time.ServerTime)
             return;
 
-        var inventoryCount = _plugin.AutoGatherListsManager.GetInventoryCountForItem(item);
+        var inventoryCount = item.GetInventoryCount();
         var quantity = _plugin.AutoGatherListsManager.GetTotalQuantitiesForItem(item);
 
         if (quantity > 0 && inventoryCount >= quantity && GatherBuddy.Config.HideGatherWindowCompletedItems)

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using Dalamud.Interface;
 using Dalamud.Interface.Components;
 using GatherBuddy.Alarms;
+using GatherBuddy.AutoGather.Extensions;
 using GatherBuddy.AutoGather.Lists;
 using GatherBuddy.Classes;
 using GatherBuddy.Config;
@@ -296,7 +297,7 @@ public partial class Interface
             }
             ImGui.SameLine();
             ImGui.Text("Inventory: ");
-            var invTotal = _plugin.AutoGatherListsManager.GetInventoryCountForItem(item);
+            var invTotal = item.GetInventoryCount();
             ImGui.SameLine(0f, ImGui.CalcTextSize($"0000 / ").X - ImGui.CalcTextSize($"{invTotal} / ").X);
             ImGui.Text($"{invTotal} / ");
             ImGui.SameLine(0, 3f);

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -302,7 +302,7 @@ public partial class Interface
             ImGui.Text($"{invTotal} / ");
             ImGui.SameLine(0, 3f);
             var quantity = list.Quantities.TryGetValue(item, out var q) ? (int)q : 1;
-            ImGui.SetNextItemWidth(100f);
+            ImGui.SetNextItemWidth(100f * Scale);
             if (ImGui.InputInt("##quantity", ref quantity, 1, 10))
                 _plugin.AutoGatherListsManager.ChangeQuantity(list, item, (uint)quantity);
             ImGui.SameLine();

--- a/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
@@ -415,17 +415,27 @@ namespace GatherBuddy.Gui
                             x => preset.CollectableAlwaysUseSolidAge = x))
                             selector.Save();
 
-                        tmp = preset.CollectableTagetScore;
-                        if (ImGui.DragInt("Target collectability score to reach before collecting", ref tmp, 1f, 0, ConfigPreset.MaxCollectability))
-                            preset.CollectableTagetScore = tmp;
-                        if (ImGui.IsItemDeactivatedAfterEdit())
+                        if (ImGuiUtil.Checkbox("Manually set collectability scores",
+                            "When disabled, collectability scores will be automatically detected from the game UI.\n" +
+                            "When enabled, you can manually specify the target and minimum scores below.",
+                            preset.CollectableManualScores,
+                            x => preset.CollectableManualScores = x))
                             selector.Save();
 
-                        tmp = preset.CollectableMinScore;
-                        if (ImGui.DragInt($"Minimum collectability score to collect at the last integrity point (set to {ConfigPreset.MaxCollectability} to disable)", ref tmp, 1f, 0, ConfigPreset.MaxCollectability))
-                            preset.CollectableMinScore = tmp;
-                        if (ImGui.IsItemDeactivatedAfterEdit())
-                            selector.Save();
+                        if (preset.CollectableManualScores)
+                        {
+                            tmp = preset.CollectableTagetScore;
+                            if (ImGui.DragInt("Target collectability score to reach before collecting", ref tmp, 1f, 0, ConfigPreset.MaxCollectability))
+                                preset.CollectableTagetScore = tmp;
+                            if (ImGui.IsItemDeactivatedAfterEdit())
+                                selector.Save();
+
+                            tmp = preset.CollectableMinScore;
+                            if (ImGui.DragInt($"Minimum collectability score to collect at the last integrity point (set to {ConfigPreset.MaxCollectability} to disable)", ref tmp, 1f, 0, ConfigPreset.MaxCollectability))
+                                preset.CollectableMinScore = tmp;
+                            if (ImGui.IsItemDeactivatedAfterEdit())
+                                selector.Save();
+                        }
                     }
 
                     if (ImGuiUtil.Checkbox("Automatically decide what actions to use",

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -85,6 +85,11 @@ public partial class Interface
                 "Automatically extract materia from items with a complete spiritbond",
                 GatherBuddy.Config.AutoGatherConfig.DoMaterialize,
                 b => GatherBuddy.Config.AutoGatherConfig.DoMaterialize = b);
+        public static void DrawAetherialReduction()
+            => DrawCheckbox("Enable Aetherial Reduction",
+                "Automatically perform Aetherial Reduction when idling or the inventory is full",
+                GatherBuddy.Config.AutoGatherConfig.DoReduce,
+                b => GatherBuddy.Config.AutoGatherConfig.DoReduce = b);
 
         public static void DrawUseFlagBox()
             => DrawCheckbox("Disable map marker navigation",            "Whether or not to navigate using map markers (timed nodes only)",
@@ -685,6 +690,7 @@ public partial class Interface
                 ConfigFunctions.DrawUseFlagBox();
                 ConfigFunctions.DrawForceWalkingBox();
                 ConfigFunctions.DrawMaterialExtraction();
+                ConfigFunctions.DrawAetherialReduction();
                 ConfigFunctions.DrawAntiStuckCooldown();
                 ConfigFunctions.DrawStuckThreshold();
                 ConfigFunctions.DrawTimedNodePrecog();

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -126,13 +126,6 @@ public partial class Interface
 
             ImGuiUtil.HoverTooltip("Delay executing each action by the specified amount.");
         }
-        public static void DrawForceCloseLingeringMasterpieceAddon()
-            => DrawCheckbox(
-                "Force close lingering GatheringMasterpiece addon (DANGEROUS, MAY CRASH THE GAME)",
-                "Attempt to forcefully close the GatheringMasterpiece addon if it is left lingering in the game memory after the end of the gathering session due to a bug",
-                GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon,
-                b => GatherBuddy.Config.AutoGatherConfig.ForceCloseLingeringMasterpieceAddon = b);
-
         public static void DrawUseGivingLandOnCooldown()
             => DrawCheckbox("Gather any crystals when The Giving Land is off cooldown", "Gather random crystals on any regular node when The Giving Land is avaiable regardles of current target item.", GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown,
                 b => GatherBuddy.Config.AutoGatherConfig.UseGivingLandOnCooldown = b);
@@ -692,7 +685,6 @@ public partial class Interface
                 ConfigFunctions.DrawUseFlagBox();
                 ConfigFunctions.DrawForceWalkingBox();
                 ConfigFunctions.DrawMaterialExtraction();
-                ConfigFunctions.DrawForceCloseLingeringMasterpieceAddon();
                 ConfigFunctions.DrawAntiStuckCooldown();
                 ConfigFunctions.DrawStuckThreshold();
                 ConfigFunctions.DrawTimedNodePrecog();

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -18,6 +18,7 @@ using OtterGui;
 using static GatherBuddy.FishTimer.FishRecord;
 using ImRaii = OtterGui.Raii.ImRaii;
 using System.Text;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 namespace GatherBuddy.Gui;
 
@@ -605,6 +606,17 @@ public partial class Interface
         //ImGui.Text($"IsSquadronManualBuffUp: {GatherBuddy.AutoGather.GetIsSquadronManualBuffUp()}");
         //ImGui.Text($"IsSquadronPassBuffUp: {GatherBuddy.AutoGather.GetIsSquadronPassBuffUp()}");
         ImGui.Text($"SortingMethodType: {GatherBuddy.Config.AutoGatherConfig.SortingMethod.ToString()}");
+
+        unsafe
+        {
+            var addon = (AddonGatheringMasterpiece*)Dalamud.GameGui.GetAddonByName("GatheringMasterpiece");
+            if (addon != null && addon->IsFullyLoaded() && addon->IsReady)
+            {
+                ImGui.Text($"Min collectability: {addon->GetComponentByNodeId(13)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText} {addon->AtkUnitBase.GetNodeById(13)->IsVisible()}");
+                ImGui.Text($"Med collectability: {addon->GetComponentByNodeId(14)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText} {addon->AtkUnitBase.GetNodeById(14)->IsVisible()}");
+                ImGui.Text($"Max collectability: {addon->GetComponentByNodeId(15)->GetTextNodeById(3)->GetAsAtkTextNode()->NodeText} {addon->AtkUnitBase.GetNodeById(15)->IsVisible()}");
+            }
+        }
 
         if (ImGui.CollapsingHeader("Timed Node Memory"))
         {

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -655,7 +655,7 @@ public partial class Interface
                 ImGui.SameLine();
                 if (ImGui.SmallButton("NavTo"))
                 {
-                    VNavmesh_IPCSubscriber.SimpleMove_PathfindAndMoveTo(obj.Position, true);
+                    VNavmesh.SimpleMove.PathfindAndMoveTo(obj.Position, true);
                 }
                 ImGui.SameLine();
                 ImGui.PopID();

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -610,11 +610,11 @@ public partial class Interface
         {
             foreach (var (location, time) in GatherBuddy.AutoGather.DebugVisitedTimedLocations)
             {
-                ImGui.Text($"{location.Id} {time.End}");
+                ImGui.Text($"{location.Name} {time.End}");
             }
         }
 
-        if (ImGui.CollapsingHeader("Visited nodes"))
+        if (ImGui.CollapsingHeader("Visited Nodes"))
         {
             foreach (var pos in GatherBuddy.AutoGather.VisitedNodes)
             {
@@ -630,11 +630,11 @@ public partial class Interface
             }
         }
 
-        if (ImGui.CollapsingHeader("Nodes to Gather"))
+        if (ImGui.CollapsingHeader("Items to Gather"))
         {
-            foreach (var item in GatherBuddy.AutoGather.ItemsToGather)
+            foreach (var x in GatherBuddy.AutoGather.ItemsToGather)
             {
-                ImGui.Text(item.Item.Name[GatherBuddy.Language]);
+                ImGui.Text($"Item: {x.Item.Name}; Location: {x.Node.Name}; Valid until: {(x.Time == TimeInterval.Always ? "Always" : x.Time.End)}; Quantity: {x.Quantity}");
             }
         }
 

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -647,6 +647,11 @@ public partial class Interface
             foreach (var x in GatherBuddy.AutoGather.ItemsToGather)
             {
                 ImGui.Text($"Item: {x.Item.Name}; Location: {x.Node.Name}; Valid until: {(x.Time == TimeInterval.Always ? "Always" : x.Time.End.ConvertToEorzea().DateTime.ToString("HH:mm", CultureInfo.InvariantCulture))} ET; Quantity: {x.Quantity}");
+                if (x.Time == TimeInterval.Always || x.Node.NodeType is not Enums.NodeType.Unspoiled and not Enums.NodeType.Legendary)
+                    continue;
+                ImGui.SameLine();
+                if (ImGui.Button("Mark Visited"))
+                    GatherBuddy.AutoGather.DebugMarkVisited(x);
             }
         }
 

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -580,7 +580,7 @@ public partial class Interface
         if (ImGui.Button("Clear Timed Node Memory"))
         {
             GatherBuddy.Log.Information("Timed node memory cleared manually!");
-            GatherBuddy.AutoGather.VisitedTimedLocations.Clear();
+            GatherBuddy.AutoGather.DebugClearVisited();
         }
 
         ImGui.Text($"Enabled: {GatherBuddy.AutoGather.Enabled}");
@@ -608,7 +608,7 @@ public partial class Interface
 
         if (ImGui.CollapsingHeader("Timed Node Memory"))
         {
-            foreach (var (location, time) in GatherBuddy.AutoGather.VisitedTimedLocations)
+            foreach (var (location, time) in GatherBuddy.AutoGather.DebugVisitedTimedLocations)
             {
                 ImGui.Text($"{location.Id} {time.End}");
             }

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -610,7 +610,7 @@ public partial class Interface
         {
             foreach (var (location, time) in GatherBuddy.AutoGather.DebugVisitedTimedLocations)
             {
-                ImGui.Text($"{location.Name} {time.End}");
+                ImGui.Text($"{location.Name} {time.End.ConvertToEorzea().DateTime.ToString("HH:mm", CultureInfo.InvariantCulture)} ET");
             }
         }
 
@@ -634,7 +634,7 @@ public partial class Interface
         {
             foreach (var x in GatherBuddy.AutoGather.ItemsToGather)
             {
-                ImGui.Text($"Item: {x.Item.Name}; Location: {x.Node.Name}; Valid until: {(x.Time == TimeInterval.Always ? "Always" : x.Time.End)}; Quantity: {x.Quantity}");
+                ImGui.Text($"Item: {x.Item.Name}; Location: {x.Node.Name}; Valid until: {(x.Time == TimeInterval.Always ? "Always" : x.Time.End.ConvertToEorzea().DateTime.ToString("HH:mm", CultureInfo.InvariantCulture))} ET; Quantity: {x.Quantity}");
             }
         }
 

--- a/GatherBuddy/Plugin/GatherBuddyIpc.cs
+++ b/GatherBuddy/Plugin/GatherBuddyIpc.cs
@@ -1,11 +1,12 @@
 ﻿using ECommons.EzIpcManager;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace GatherBuddy.Plugin;
 
 public class GatherBuddyIpc : IDisposable
 {
-    public const int IpcVersion = 1;
+    public const int IpcVersion = 2;
 
     private readonly GatherBuddy _plugin;
 
@@ -15,14 +16,41 @@ public class GatherBuddyIpc : IDisposable
         EzIPC.Init(this, GatherBuddy.InternalName);
     }
 
+#pragma warning disable CA1822 // Mark members as static
     [EzIPC]
-    private static int Version()
+    public int Version()
         => IpcVersion;
 
     [EzIPC]
-    private uint Identify(string text)
+    public uint Identify(string text)
         => _plugin.Executor.Identificator.IdentifyGatherable(text)?.ItemId
          ?? _plugin.Executor.Identificator.IdentifyFish(text)?.ItemId ?? 0;
+
+    [EzIPC]
+    public bool IsAutoGatherEnabled()
+        => GatherBuddy.AutoGather.Enabled;
+
+    [EzIPC]
+    public string GetAutoGatherStatusText()
+        => GatherBuddy.AutoGather.AutoStatus;
+
+    [EzIPC]
+    public void SetAutoGatherEnabled(bool enabled)
+        => GatherBuddy.AutoGather.Enabled = enabled;
+
+    [EzIPC]
+    public bool IsAutoGatherWaiting()
+        => GatherBuddy.AutoGather.Waiting;
+
+    [EzIPCEvent]
+    [AllowNull]
+    public Action AutoGatherWaiting;
+
+    [EzIPCEvent]
+    [AllowNull]
+    public Action<bool> AutoGatherEnabledChanged;
+
+#pragma warning restore CA1822 // Mark members as static
 
     public void Dispose()
     {

--- a/GatherBuddy/Plugin/GatherBuddyIpc.cs
+++ b/GatherBuddy/Plugin/GatherBuddyIpc.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace GatherBuddy.Plugin;
 
-public class GatherBuddyIpc : IDisposable
+public sealed class GatherBuddyIpc : IDisposable
 {
     public const int IpcVersion = 2;
 
@@ -43,12 +43,10 @@ public class GatherBuddyIpc : IDisposable
         => GatherBuddy.AutoGather.Waiting;
 
     [EzIPCEvent]
-    [AllowNull]
-    public Action AutoGatherWaiting;
+    public readonly Action? AutoGatherWaiting;
 
     [EzIPCEvent]
-    [AllowNull]
-    public Action<bool> AutoGatherEnabledChanged;
+    public readonly Action<bool>? AutoGatherEnabledChanged;
 
 #pragma warning restore CA1822 // Mark members as static
 

--- a/GatherBuddy/Plugin/GatherBuddyIpc.cs
+++ b/GatherBuddy/Plugin/GatherBuddyIpc.cs
@@ -1,6 +1,6 @@
 ﻿using ECommons.EzIpcManager;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 
 namespace GatherBuddy.Plugin;
 
@@ -14,6 +14,8 @@ public sealed class GatherBuddyIpc : IDisposable
     {
         _plugin = plugin;
         EzIPC.Init(this, GatherBuddy.InternalName);
+        Debug.Assert(AutoGatherWaiting != null);
+        Debug.Assert(AutoGatherEnabledChanged != null);
     }
 
 #pragma warning disable CA1822 // Mark members as static
@@ -43,10 +45,10 @@ public sealed class GatherBuddyIpc : IDisposable
         => GatherBuddy.AutoGather.Waiting;
 
     [EzIPCEvent]
-    public readonly Action? AutoGatherWaiting;
+    public readonly Action AutoGatherWaiting;
 
     [EzIPCEvent]
-    public readonly Action<bool>? AutoGatherEnabledChanged;
+    public readonly Action<bool> AutoGatherEnabledChanged;
 
 #pragma warning restore CA1822 // Mark members as static
 

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -7,6 +7,7 @@ using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
 
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 namespace GatherBuddy.Plugin
 {
     internal static class IPCSubscriber

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -1,148 +1,210 @@
-﻿using Dalamud.Plugin.Ipc;
-using Dalamud.Plugin.Ipc.Exceptions;
-using Dalamud.Plugin.Services;
-using ECommons.DalamudServices;
-using ECommons.EzIpcManager;
+﻿using ECommons.EzIpcManager;
 using ECommons.Reflection;
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Numerics;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace GatherBuddy.Plugin
 {
-    internal class IPCSubscriber_Common
+    internal static class IPCSubscriber
     {
-        internal static bool IsReady(string pluginName)
+        public static bool IsReady(string pluginName)
             => DalamudReflector.TryGetDalamudPlugin(pluginName, out _, false, true);
+    }
 
-        internal static void DisposeAll(EzIPCDisposalToken[] _disposalTokens)
+    internal static class VNavmesh
+    {
+        internal static bool Enabled
+            => IPCSubscriber.IsReady("vnavmesh");
+
+        internal static class Nav
         {
-            foreach (var token in _disposalTokens)
+            static Nav()
             {
-                try
-                {
-                    token.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    Svc.Log.Error($"Error while unregistering IPC: {ex}");
-                }
+                EzIPC.Init(typeof(Nav), "vnavmesh");
+                Debug.Assert(IsReady != null);
+                Debug.Assert(BuildProgress != null);
+                Debug.Assert(Reload != null);
+                Debug.Assert(Rebuild != null);
+                Debug.Assert(Pathfind != null);
+                Debug.Assert(PathfindCancelable != null);
+                Debug.Assert(PathfindCancelAll != null);
+                Debug.Assert(PathfindInProgress != null);
+                Debug.Assert(PathfindNumQueued != null);
+                Debug.Assert(IsAutoLoad != null);
+                Debug.Assert(SetAutoLoad != null);
             }
+
+            [EzIPC("vnavmesh.Nav.IsReady", applyPrefix: false)]
+            internal static readonly Func<bool> IsReady;
+
+            [EzIPC("vnavmesh.Nav.BuildProgress", applyPrefix: false)]
+            internal static readonly Func<float> BuildProgress;
+
+            [EzIPC("vnavmesh.Nav.Reload", applyPrefix: false)]
+            internal static readonly Func<bool> Reload;
+
+            [EzIPC("vnavmesh.Nav.Rebuild", applyPrefix: false)]
+            internal static readonly Func<bool> Rebuild;
+
+            [EzIPC("vnavmesh.Nav.Pathfind", applyPrefix: false)]
+            internal static readonly Func<Vector3, Vector3, bool, Task<List<Vector3>>> Pathfind;
+
+            [EzIPC("vnavmesh.Nav.PathfindCancelable", applyPrefix: false)]
+            internal static readonly Func<Vector3, Vector3, bool, CancellationToken, Task<List<Vector3>>> PathfindCancelable;
+
+            [EzIPC("vnavmesh.Nav.PathfindCancelAll", applyPrefix: false)]
+            internal static readonly Action PathfindCancelAll;
+
+            [EzIPC("vnavmesh.Nav.PathfindInProgress", applyPrefix: false)]
+            internal static readonly Func<bool> PathfindInProgress;
+
+            [EzIPC("vnavmesh.Nav.PathfindNumQueued", applyPrefix: false)]
+            internal static readonly Func<int> PathfindNumQueued;
+
+            [EzIPC("vnavmesh.Nav.IsAutoLoad", applyPrefix: false)]
+            internal static readonly Func<bool> IsAutoLoad;
+
+            [EzIPC("vnavmesh.Nav.SetAutoLoad", applyPrefix: false)]
+            internal static readonly Action<bool> SetAutoLoad;
+        }
+
+        internal static class Query
+        {
+            internal static class Mesh
+            {
+                static Mesh()
+                {
+                    EzIPC.Init(typeof(Mesh), "vnavmesh");
+                    Debug.Assert(NearestPoint != null);
+                    Debug.Assert(PointOnFloor != null);
+                }
+
+                [EzIPC("vnavmesh.Query.Mesh.NearestPoint", applyPrefix: false)]
+                internal static readonly Func<Vector3, float, float, Vector3> NearestPoint;
+
+                [EzIPC("vnavmesh.Query.Mesh.PointOnFloor", applyPrefix: false)]
+                internal static readonly Func<Vector3, bool, float, Vector3> PointOnFloor;
+            }
+        }
+
+        internal static class Path
+        {
+            static Path()
+            {
+                EzIPC.Init(typeof(Path), "vnavmesh");
+                Debug.Assert(MoveTo != null);
+                Debug.Assert(Stop != null);
+                Debug.Assert(IsRunning != null);
+                Debug.Assert(NumWaypoints != null);
+                Debug.Assert(GetMovementAllowed != null);
+                Debug.Assert(SetMovementAllowed != null);
+                Debug.Assert(GetAlignCamera != null);
+                Debug.Assert(SetAlignCamera != null);
+                Debug.Assert(GetTolerance != null);
+                Debug.Assert(SetTolerance != null);
+            }
+
+            [EzIPC("vnavmesh.Path.MoveTo", applyPrefix: false)]
+            internal static readonly Action<List<Vector3>, bool> MoveTo;
+
+            [EzIPC("vnavmesh.Path.Stop", applyPrefix: false)]
+            internal static readonly Action Stop;
+
+            [EzIPC("vnavmesh.Path.IsRunning", applyPrefix: false)]
+            internal static readonly Func<bool> IsRunning;
+
+            [EzIPC("vnavmesh.Path.NumWaypoints", applyPrefix: false)]
+            internal static readonly Func<int> NumWaypoints;
+
+            [EzIPC("vnavmesh.Path.GetMovementAllowed", applyPrefix: false)]
+            internal static readonly Func<bool> GetMovementAllowed;
+
+            [EzIPC("vnavmesh.Path.SetMovementAllowed", applyPrefix: false)]
+            internal static readonly Action<bool> SetMovementAllowed;
+
+            [EzIPC("vnavmesh.Path.GetAlignCamera", applyPrefix: false)]
+            internal static readonly Func<bool> GetAlignCamera;
+
+            [EzIPC("vnavmesh.Path.SetAlignCamera", applyPrefix: false)]
+            internal static readonly Action<bool> SetAlignCamera;
+
+            [EzIPC("vnavmesh.Path.GetTolerance", applyPrefix: false)]
+            internal static readonly Func<float> GetTolerance;
+
+            [EzIPC("vnavmesh.Path.SetTolerance", applyPrefix: false)]
+            internal static readonly Action<float> SetTolerance;
+        }
+
+        internal static class SimpleMove
+        {
+            static SimpleMove()
+            {
+                EzIPC.Init(typeof(SimpleMove), "vnavmesh");
+                Debug.Assert(PathfindAndMoveTo != null);
+                Debug.Assert(PathfindInProgress != null);
+            }
+
+            [EzIPC("vnavmesh.SimpleMove.PathfindAndMoveTo", applyPrefix: false)]
+            internal static readonly Func<Vector3, bool, bool> PathfindAndMoveTo;
+
+            [EzIPC("vnavmesh.SimpleMove.PathfindInProgress", applyPrefix: false)]
+            internal static readonly Func<bool> PathfindInProgress;
+        }
+
+        internal static class Window
+        {
+            static Window()
+            {
+                EzIPC.Init(typeof(Window), "vnavmesh");
+                Debug.Assert(IsOpen != null);
+                Debug.Assert(SetOpen != null);
+            }
+
+            [EzIPC("vnavmesh.Window.IsOpen", applyPrefix: false)]
+            internal static readonly Func<bool> IsOpen;
+
+            [EzIPC("vnavmesh.Window.SetOpen", applyPrefix: false)]
+            internal static readonly Action<bool> SetOpen;
+        }
+
+        internal static class DTR
+        {
+            static DTR()
+            {
+                EzIPC.Init(typeof(DTR), "vnavmesh");
+                Debug.Assert(IsShown != null);
+                Debug.Assert(SetShown != null);
+            }
+
+            [EzIPC("vnavmesh.DTR.IsShown", applyPrefix: false)]
+            internal static readonly Func<bool> IsShown;
+
+            [EzIPC("vnavmesh.DTR.SetShown", applyPrefix: false)]
+            internal static readonly Action<bool> SetShown;
         }
     }
 
-    internal static class VNavmesh_IPCSubscriber
+    internal static class Lifestream
     {
-        private static EzIPCDisposalToken[] _disposalTokens = EzIPC.Init(typeof(VNavmesh_IPCSubscriber), "vnavmesh");
+        static Lifestream()
+        {
+            EzIPC.Init(typeof(Lifestream), "Lifestream");
+            Debug.Assert(ExecuteCommand != null);
+            Debug.Assert(IsBusy != null);
+            Debug.Assert(Abort != null);
+            Debug.Assert(AethernetTeleport != null);
+        }
 
-        internal static bool IsEnabled
-            => IPCSubscriber_Common.IsReady("vnavmesh");
-
-        [EzIPC("vnavmesh.Nav.IsReady", applyPrefix: false)]
-        internal static readonly Func<bool> Nav_IsReady;
-
-        [EzIPC("vnavmesh.Nav.BuildProgress", applyPrefix: false)]
-        internal static readonly Func<float> Nav_BuildProgress;
-
-        [EzIPC("vnavmesh.Nav.Reload", applyPrefix: false)]
-        internal static readonly Func<bool> Nav_Reload;
-
-        [EzIPC("vnavmesh.Nav.Rebuild", applyPrefix: false)]
-        internal static readonly Func<bool> Nav_Rebuild;
-
-        [EzIPC("vnavmesh.Nav.Pathfind", applyPrefix: false)]
-        internal static readonly Func<Vector3, Vector3, bool, Task<List<Vector3>>> Nav_Pathfind;
-
-        [EzIPC("vnavmesh.Nav.PathfindCancelable", applyPrefix: false)]
-        internal static readonly Func<Vector3, Vector3, bool, CancellationToken, Task<List<Vector3>>> Nav_PathfindCancelable;
-
-        [EzIPC("vnavmesh.Nav.PathfindCancelAll", applyPrefix: false)]
-        internal static readonly Action Nav_PathfindCancelAll;
-
-        [EzIPC("vnavmesh.Nav.PathfindInProgress", applyPrefix: false)]
-        internal static readonly Func<bool> Nav_PathfindInProgress;
-
-        [EzIPC("vnavmesh.Nav.PathfindNumQueued", applyPrefix: false)]
-        internal static readonly Func<int> Nav_PathfindNumQueued;
-
-        [EzIPC("vnavmesh.Nav.IsAutoLoad", applyPrefix: false)]
-        internal static readonly Func<bool> Nav_IsAutoLoad;
-
-        [EzIPC("vnavmesh.Nav.SetAutoLoad", applyPrefix: false)]
-        internal static readonly Action<bool> Nav_SetAutoLoad;
-
-        [EzIPC("vnavmesh.Query.Mesh.NearestPoint", applyPrefix: false)]
-        internal static readonly Func<Vector3, float, float, Vector3> Query_Mesh_NearestPoint;
-
-        [EzIPC("vnavmesh.Query.Mesh.PointOnFloor", applyPrefix: false)]
-        internal static readonly Func<Vector3, bool, float, Vector3> Query_Mesh_PointOnFloor;
-
-        [EzIPC("vnavmesh.Path.MoveTo", applyPrefix: false)]
-        internal static readonly Action<List<Vector3>, bool> Path_MoveTo;
-
-        [EzIPC("vnavmesh.Path.Stop", applyPrefix: false)]
-        internal static readonly Action Path_Stop;
-
-        [EzIPC("vnavmesh.Path.IsRunning", applyPrefix: false)]
-        internal static readonly Func<bool> Path_IsRunning;
-
-        [EzIPC("vnavmesh.Path.NumWaypoints", applyPrefix: false)]
-        internal static readonly Func<int> Path_NumWaypoints;
-
-        [EzIPC("vnavmesh.Path.GetMovementAllowed", applyPrefix: false)]
-        internal static readonly Func<bool> Path_GetMovementAllowed;
-
-        [EzIPC("vnavmesh.Path.SetMovementAllowed", applyPrefix: false)]
-        internal static readonly Action<bool> Path_SetMovementAllowed;
-
-        [EzIPC("vnavmesh.Path.GetAlignCamera", applyPrefix: false)]
-        internal static readonly Func<bool> Path_GetAlignCamera;
-
-        [EzIPC("vnavmesh.Path.SetAlignCamera", applyPrefix: false)]
-        internal static readonly Action<bool> Path_SetAlignCamera;
-
-        [EzIPC("vnavmesh.Path.GetTolerance", applyPrefix: false)]
-        internal static readonly Func<float> Path_GetTolerance;
-
-        [EzIPC("vnavmesh.Path.SetTolerance", applyPrefix: false)]
-        internal static readonly Action<float> Path_SetTolerance;
-
-        [EzIPC("vnavmesh.SimpleMove.PathfindAndMoveTo", applyPrefix: false)]
-        internal static readonly Func<Vector3, bool, bool> SimpleMove_PathfindAndMoveTo;
-
-        [EzIPC("vnavmesh.SimpleMove.PathfindInProgress", applyPrefix: false)]
-        internal static readonly Func<bool> SimpleMove_PathfindInProgress;
-
-        [EzIPC("vnavmesh.Window.IsOpen", applyPrefix: false)]
-        internal static readonly Func<bool> Window_IsOpen;
-
-        [EzIPC("vnavmesh.Window.SetOpen", applyPrefix: false)]
-        internal static readonly Action<bool> Window_SetOpen;
-
-        [EzIPC("vnavmesh.DTR.IsShown", applyPrefix: false)]
-        internal static readonly Func<bool> DTR_IsShown;
-
-        [EzIPC("vnavmesh.DTR.SetShown", applyPrefix: false)]
-        internal static readonly Action<bool> DTR_SetShown;
-
-        internal static void Dispose()
-            => IPCSubscriber_Common.DisposeAll(_disposalTokens);
-    }
-
-    internal static class Lifestream_IPCSubscriber
-    {
-        private static EzIPCDisposalToken[] _disposalTokens = EzIPC.Init(typeof(Lifestream_IPCSubscriber), "Lifestream");
-
-        internal static bool IsEnabled
-            => IPCSubscriber_Common.IsReady("Lifestream");
+        internal static bool Enabled
+            => IPCSubscriber.IsReady("Lifestream");
 
         [EzIPC("Lifestream.ExecuteCommand", applyPrefix: false)]
         internal static readonly Action<string> ExecuteCommand;
-        
+
         [EzIPC("Lifestream.IsBusy", applyPrefix: false)]
         internal static readonly Func<bool> IsBusy;
 
@@ -151,8 +213,5 @@ namespace GatherBuddy.Plugin
 
         [EzIPC("Lifestream.AethernetTeleport", applyPrefix: false)]
         internal static readonly Func<string, bool> AethernetTeleport;
-
-        internal static void Dispose()
-            => IPCSubscriber_Common.DisposeAll(_disposalTokens);
     }
 }


### PR DESCRIPTION
- Use a callback to close MaterializeAddon .
- Ignore mesh correction when the result is too far from the node (>0.5 yalms of max).
- Remove lingering GatheringMasterpiece addon detection.
- Add a perception check before gathering a node.
- Ignore items and locations that can't be gathered at the current job level.
- When sorting by location is enabled, prioritize items within the current location by distance to the player; otherwise, sort by teleportation cost.
- For items with multiple nodes, prioritize the current territory (and choose the closest nodes within it), then prioritize the cheapest Aetheryte or the node closest to its nearest Aetheryte, depending on settings.
- Change jobs after teleportation, not before.
- Implement automatic aetherial reduction triggered when fewer than 20 inventory slots remain, or when idling.
- Automatically detect required collectability score.
- Enabling auto-gather when a node is already open is now properly handled. Previously, the node would have been closed.
- Improved the distance-to-node check by separately checking vertical and horizontal separation.
- New IPC methods and events.
- Some refactoring.