### PR TITLE
Add automatic aetherial reduction

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -60,6 +60,7 @@ namespace GatherBuddy.AutoGather
         [Obsolete] public ConsumableConfig SquadronManualConfig { get; set; } = new(false, 0, 0, 0);
         [Obsolete] public ConsumableConfig SquadronPassConfig { get; set; } = new(false, 0, 0, 0);
         public bool DoMaterialize { get; set; } = false;
+        public bool DoReduce { get; set; } = false;
         public bool HonkMode { get; set; } = true;
         public SortingType SortingMethod { get; set; } = SortingType.Location;
         public bool GoHomeWhenIdle { get; set; } = true;

--- a/GatherBuddy/AutoGather/AutoGather.Purify.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Purify.cs
@@ -1,0 +1,96 @@
+﻿using FFXIVClientStructs.FFXIV.Client.Game;
+using GatherBuddy.Plugin;
+using Dalamud.Game.ClientState.Conditions;
+using PurifyResult = ECommons.UIHelpers.AddonMasterImplementations.AddonMaster.PurifyResult;
+using ECommons.Automation;
+using ECommons.DalamudServices;
+
+namespace GatherBuddy.AutoGather
+{
+    public partial class AutoGather
+    {
+        private bool HasReducibleItems()
+        {
+            if (!GatherBuddy.Config.AutoGatherConfig.DoReduce || Svc.Condition[ConditionFlag.Mounted]) return false;
+
+            if (!QuestManager.IsQuestComplete(67633)) // No Longer a Collectable
+            {
+                GatherBuddy.Config.AutoGatherConfig.DoReduce = false;
+                Communicator.PrintError("[GatherBuddyReborn] Aetherial reduction is enabled, but the relevant quest has not been completed yet. The feature has been disabled.");
+                return false;
+            }
+
+            unsafe
+            {
+                var manager = InventoryManager.Instance();
+                if (manager == null)
+                    return false;
+
+                foreach (var invType in InventoryTypes)
+                {
+                    var container = manager->GetInventoryContainer(invType);
+                    if (container == null || container->Loaded == 0)
+                        continue;
+
+                    for (int i = 0; i < container->Size; i++)
+                    {
+                        var slot = container->GetInventorySlot(i);
+                        if (slot != null
+                            && slot->ItemId != 0
+                            && GatherBuddy.GameData.Gatherables.TryGetValue(slot->ItemId, out var gatherable)
+                            && gatherable.ItemData.AetherialReduce != 0)
+                        {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            }
+        }
+
+        private unsafe void ReduceItems(bool reduceAll)
+        {
+            AutoStatus = "Aetherial reduction";
+            var delay = (int)GatherBuddy.Config.AutoGatherConfig.ExecutionDelay;
+            TaskManager.Enqueue(StopNavigation);
+            if (PurifyItemSelectorAddon == null)
+            {
+                EnqueueActionWithDelay(() => { ActionManager.Instance()->UseAction(ActionType.GeneralAction, 21); });
+                // Prevent the "Unable to execute command while occupied" message right after entering a house.
+                TaskManager.DelayNext(500);
+            }
+
+            TaskManager.Enqueue(ReduceFirstItem, 3000, true, "Reduce first item");
+            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39], 5000, true, "Wait until first item reduction is complete");
+            TaskManager.DelayNext(delay);
+            TaskManager.Enqueue(StartAutoReduction, 1000, true, "Start auto reduction");
+            TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.Occupied39], 180000, true, "Wait until all items have been reduced");
+            TaskManager.DelayNext(delay);
+            TaskManager.Enqueue(() => {
+                EnqueueActionWithDelay(() => { if (PurifyResultAddon is var addon and not null) Callback.Fire(addon, true, -1); });
+                if (reduceAll && HasReducibleItems())
+                    ReduceItems(true);
+                else
+                    EnqueueActionWithDelay(() => { if (PurifyItemSelectorAddon is var addon and not null) Callback.Fire(addon, true, -1); });
+            });
+        }
+
+        private unsafe bool? ReduceFirstItem()
+        {
+            var addon = PurifyItemSelectorAddon;
+            if (addon == null) return false;
+
+            Callback.Fire(addon, true, 12, 0u);
+            return true;
+        }
+
+        private unsafe bool? StartAutoReduction()
+        {
+            var addon = PurifyResultAddon;
+            if (addon == null) return false;
+
+            new PurifyResult(addon).Automatic();
+            return true;
+        }
+    }
+}

--- a/GatherBuddy/AutoGather/AutoGather.Purify.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Purify.cs
@@ -29,7 +29,7 @@ namespace GatherBuddy.AutoGather
                 foreach (var invType in InventoryTypes)
                 {
                     var container = manager->GetInventoryContainer(invType);
-                    if (container == null || container->Loaded == 0)
+                    if (container == null || !container->IsLoaded)
                         continue;
 
                     for (int i = 0; i < container->Size; i++)

--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -14,6 +14,8 @@ public partial class AutoGather
     {
         get
         {
+            if (!GatherBuddy.Config.AutoGatherConfig.DoMaterialize) return 0;
+
             var inventory = InventoryManager.Instance()->GetInventoryContainer(InventoryType.EquippedItems);
             var result    = 0;
             for (var slot = 0; slot < inventory->Size; slot++)

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -222,7 +222,7 @@ namespace GatherBuddy.AutoGather
                     DoMateriaExtraction();
                     return;
                 }
-                if (FreeInventorySlots < 10 && HasReducibleItems())
+                if (FreeInventorySlots < 20 && HasReducibleItems())
                 {
                     ReduceItems(false);
                     return;

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -100,7 +100,7 @@ public partial class AutoGatherListsManager : IDisposable
             var manager = InventoryManager.Instance();
             if (manager == null)
                 return count;
-            foreach (var inv in InventoryTypes)
+            foreach (var inv in AutoGather.InventoryTypes)
             {
                 var container = manager->GetInventoryContainer(inv);
                 if (container == null || container->Loaded == 0)
@@ -123,21 +123,6 @@ public partial class AutoGatherListsManager : IDisposable
         }
     }
     
-    public List<InventoryType> InventoryTypes
-    {
-        get
-        {
-            List<InventoryType> types = new List<InventoryType>()
-            {
-                InventoryType.Inventory1,
-                InventoryType.Inventory2,
-                InventoryType.Inventory3,
-                InventoryType.Inventory4,
-            };
-            return types;
-        }
-    }
-
     public void Save()
     {
         var file = Functions.ObtainSaveFile(FileName);

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -85,6 +85,11 @@ public partial class Interface
                 "Automatically extract materia from items with a complete spiritbond",
                 GatherBuddy.Config.AutoGatherConfig.DoMaterialize,
                 b => GatherBuddy.Config.AutoGatherConfig.DoMaterialize = b);
+        public static void DrawAetherialReduction()
+            => DrawCheckbox("Enable Aetherial Reduction",
+                "Automatically perform Aetherial Reduction when idling or the inventory is full",
+                GatherBuddy.Config.AutoGatherConfig.DoReduce,
+                b => GatherBuddy.Config.AutoGatherConfig.DoReduce = b);
 
         public static void DrawUseFlagBox()
             => DrawCheckbox("Disable map marker navigation",            "Whether or not to navigate using map markers (timed nodes only)",
@@ -692,6 +697,7 @@ public partial class Interface
                 ConfigFunctions.DrawUseFlagBox();
                 ConfigFunctions.DrawForceWalkingBox();
                 ConfigFunctions.DrawMaterialExtraction();
+                ConfigFunctions.DrawAetherialReduction();
                 ConfigFunctions.DrawForceCloseLingeringMasterpieceAddon();
                 ConfigFunctions.DrawAntiStuckCooldown();
                 ConfigFunctions.DrawStuckThreshold();


### PR DESCRIPTION
Implement automatic aetherial reduction triggered when fewer than 20 inventory slots remain, or when idling.
Reduction requires the character to be unmounted but won’t proactively unmount just to perform it.
Not tested with YesAlready.