### PR TITLE
Integrate YesAlready locking to prevent conflicts during tasks

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Spiritbond.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Dalamud.Game.ClientState.Conditions;
 using ECommons.Automation;
 using ECommons.DalamudServices;
@@ -51,6 +52,7 @@ public partial class AutoGather
             return;
         }
 
+        TaskManager.Enqueue(YesAlready.Lock);
         EnqueueActionWithDelay(() => { if (MaterializeAddon is var addon and not null) Callback.Fire(&addon->AtkUnitBase, true, 2, 0); });
         TaskManager.Enqueue(() => MaterializeDialogAddon != null, 1000);
         EnqueueActionWithDelay(() => { if (MaterializeDialogAddon is var addon and not null) new MaterializeDialog(addon).Materialize(); });
@@ -59,6 +61,7 @@ public partial class AutoGather
         if (SpiritbondMax == 1) 
         {
             EnqueueActionWithDelay(() => { if (MaterializeAddon is var addon and not null) Callback.Fire(&addon->AtkUnitBase, true, -1); });
+            TaskManager.Enqueue(YesAlready.Unlock);
         }
     }
 }

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -6,6 +6,8 @@ using System.Diagnostics;
 using System.Numerics;
 using System.Threading;
 using System.Threading.Tasks;
+using ECommons.DalamudServices;
+using ECommons.EzSharedDataManager;
 
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
 namespace GatherBuddy.Plugin
@@ -214,5 +216,23 @@ namespace GatherBuddy.Plugin
 
         [EzIPC("Lifestream.AethernetTeleport", applyPrefix: false)]
         internal static readonly Func<string, bool> AethernetTeleport;
+    }
+
+    internal static class YesAlready
+    {
+        internal static void Lock()
+        {
+            if (EzSharedData.TryGet<HashSet<string>>("YesAlready.StopRequests", out var stopRequests))
+            {
+                stopRequests.Add(Svc.PluginInterface.InternalName);
+            }
+        }
+        internal static void Unlock()
+        {
+            if (EzSharedData.TryGet<HashSet<string>>("YesAlready.StopRequests", out var stopRequests))
+            {
+                stopRequests.Remove(Svc.PluginInterface.InternalName);
+            }
+        }
     }
 }


### PR DESCRIPTION
Added YesAlready.Lock and YesAlready.Unlock calls to manage task execution safety during automated operations like spiritbond materialization and aetherial reduction. This ensures other plugins cannot interfere with these processes, improving reliability and user experience.