### PR TITLE
Fix incorrect filtering logic for required home world items

### DIFF
--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -149,7 +149,7 @@ namespace GatherBuddy.AutoGather.Lists
             var nodes = _listsManager.ActiveItems
                 // Filter out items that are already gathered.
                 .Where(NeedsGathering)
-                .Where(x => RequiresHomeWorld(x) && Functions.OnHomeWorld())
+                .Where(x => (RequiresHomeWorld(x) && Functions.OnHomeWorld()) || !RequiresHomeWorld(x))
                 // If treasure map, only gather if the allowance is up.
                 .Where(x => !x.Item.IsTreasureMap || (nextAllowance ??= DiscipleOfLand.NextTreasureMapAllowance) < adjustedServerTime.DateTime)
                 // Fetch preferred location.


### PR DESCRIPTION
Previously, items not requiring the home world were being improperly excluded due to flawed conditional logic. This update ensures items are correctly included based on whether they require the home world or not, aligning behavior with intended functionality.