### PR TITLE
Add per-item enable/disable functionality to AutoGather lists

### DIFF
--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.ManipPreset.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.ManipPreset.cs
@@ -109,6 +109,16 @@ public partial class AutoGatherListsManager
         }
     }
 
+    public void ChangeEnabled(AutoGatherList list, Gatherable item, bool enabled)
+    {
+        if (list.SetEnabled(item, enabled))
+        {
+            Save();
+            if (list.Enabled)
+                SetActiveItems();
+        }
+    }
+
     public void MoveItem(AutoGatherList list, int idx1, int idx2)
     {
         if (list.Move(idx1, idx2))

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -38,7 +38,8 @@ public partial class AutoGatherListsManager : IDisposable
         _fallbackItems.Clear();
         var items = _lists
             .Where(l => l.Enabled)
-            .SelectMany(l => l.Items.Select(i => (Item: i, Quantity: l.Quantities[i], l.Fallback)))
+            .SelectMany(l => l.Items.Select(i => (Item: i, Quantity: l.Quantities[i], l.Fallback, ItemEnabled: l.EnabledItems[i])))
+            .Where(i => i.ItemEnabled)
             .GroupBy(i => (i.Item, i.Fallback))
             .Select(x => (x.Key.Item, Quantity: (uint)Math.Min(x.Sum(g => g.Quantity), uint.MaxValue), x.Key.Fallback));
         

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -341,6 +341,11 @@ public partial class Interface
             if (ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Trash.ToIconString(), IconButtonSize, "Delete this item from the list", false,
                     true))
                 deleteIndex = i;
+            ImGui.SameLine();
+
+            var enabled = list.EnabledItems[item];
+            if (ImGui.Checkbox($"##{item.ItemId}", ref enabled))
+                _plugin.AutoGatherListsManager.ChangeEnabled(list, item, enabled);
 
             ImGui.SameLine();
             if (selector.Draw(item.Name[GatherBuddy.Language], out var newIdx))


### PR DESCRIPTION
Introduced individual item enable/disable control within AutoGather lists, allowing users to toggle items dynamically. Updated associated logic, GUI, and configuration data to support this feature, including migration for backward compatibility.