### PR TITLE
Refactor gathering buff activation sequence.

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -488,9 +488,6 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (ActivateGatheringBuffs(next.First().Item.NodeType is NodeType.Unspoiled or NodeType.Legendary))
-                return;
-
             var config = MatchConfigPreset(next.First().Item);
 
             if (DoUseConsumablesWithoutCastTime(config))
@@ -517,6 +514,9 @@ namespace GatherBuddy.AutoGather
 
                 return;
             }
+
+            if (ActivateGatheringBuffs(next.First().Item.NodeType is NodeType.Unspoiled or NodeType.Legendary))
+                return;
 
             if (closestTargetableNode != null)
             {


### PR DESCRIPTION
Moved the gathering buffs activation logic to occur after gear set changes. This ensures buffs are applied under the correct conditions and aligns with the appropriate execution order for improved reliability.