### PR TITLE
Add configurable Lifestream command for custom usage

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -74,6 +74,7 @@ namespace GatherBuddy.AutoGather
         public bool RotationSolverConversionDone { get; set; } = false;
         [Obsolete] public bool HandleArtisanListsAutomatically { get; set; } = true;
         public bool CheckRetainers { get; set; } = false;
+        public string LifestreamCommand { get; set; } = "auto";
         public enum SortingType
         {
             None = 0,

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -114,7 +114,10 @@ namespace GatherBuddy.AutoGather
 
             if (Lifestream.Enabled && !Lifestream.IsBusy())
             {
-                Lifestream.ExecuteCommand("auto");
+                var command = GatherBuddy.Config.AutoGatherConfig.LifestreamCommand;
+                if (command.Contains("/li "))
+                    command = command.Replace("/li ", "");
+                Lifestream.ExecuteCommand(command);
                 TaskManager.EnqueueImmediate(() => !Lifestream.IsBusy(), 120000, "Wait until Lifestream is done");
                 return true;
             }

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -105,6 +105,19 @@ public partial class Interface
             ImGuiUtil.HoverTooltip("The percentage of durability at which you will repair your gear.");
         }
 
+        public static void DrawLifestreamCommandTextInput()
+        {
+            var tmp = GatherBuddy.Config.AutoGatherConfig.LifestreamCommand;
+            if (ImGui.InputText("Lifestream Command", ref tmp, 100))
+            {
+                if (string.IsNullOrEmpty(tmp))
+                    tmp = "auto";
+                GatherBuddy.Config.AutoGatherConfig.LifestreamCommand = tmp;
+                GatherBuddy.Config.Save();
+            }
+            ImGuiUtil.HoverTooltip("The command used when idling or done gathering. DO NOT include '/li'\nBe careful when changing this, GBR does not validate this command!");
+        }
+
         public static void DrawMaterialExtraction()
             => DrawCheckbox("Enable materia extraction",
                 "Automatically extract materia from items with a complete spiritbond",
@@ -724,9 +737,9 @@ public partial class Interface
                 {
                     ConfigFunctions.DrawRepairThreshold();
                 }
-
                 ConfigFunctions.DrawMaterialExtraction();
                 ConfigFunctions.DrawAetherialReduction();
+                ConfigFunctions.DrawLifestreamCommandTextInput();
                 ConfigFunctions.DrawAntiStuckCooldown();
                 ConfigFunctions.DrawStuckThreshold();
                 ConfigFunctions.DrawTimedNodePrecog();


### PR DESCRIPTION
Introduced a new `LifestreamCommand` property to allow customization of the default command executed when idle or done gathering. Updated the UI to include a text input for modifying this command and adjusted logic to ensure commands are properly formatted before execution.