### PR TITLE
Increase max quantity limit to 999999.

### DIFF
--- a/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
@@ -113,8 +113,8 @@ public class AutoGatherList
     {
         if (quantity < 1)
             quantity = 1;
-        if (quantity > 9999)
-            quantity = 9999;
+        if (quantity > 999999)
+            quantity = 999999;
         if (quantity > 1 && item.IsTreasureMap)
             quantity = 1;
         return quantity;


### PR DESCRIPTION
Updated the upper limit for item quantity from 9999 to 999999 to accommodate larger numbers. Ensured the restriction for treasure maps remains unchanged.