### PR TITLE
Refactor CI workflow to separate plugin and web jobs

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,10 +4,9 @@ on:
     tags:
       - '*.*.*.*'
 jobs:
-  Build:
+  Plugin:
     permissions:
       contents: write
-      packages: write
     runs-on: windows-latest
     env:
       REPO_NAME: ${{ github.repository }}
@@ -23,25 +22,10 @@ jobs:
 
           "tag=$tag" | Out-File -Append -FilePath $Env:GITHUB_ENV
 
-      - name: Set Lowercase Repo Name
-        run: echo "REPO_NAME_LOWER=$(echo $REPO_NAME | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-
       - name: Set up .NET
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 9.0.x
-
-      - name: Set up Docker
-        uses: docker/setup-buildx-action@v3
-        with:
-          install: 'true'
-
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Dalamud Latest
         run: |
@@ -57,8 +41,49 @@ jobs:
       - name: Zip Plugin
         run: Compress-Archive -Path .\build\* -DestinationPath .\build\GatherbuddyReborn.zip
 
+      - name: Publish Plugin
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ./build/GatherbuddyReborn.zip
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  Web:
+    permissions:
+      contents: read
+      packages: write
+    runs-on: ubuntu-latest
+    env:
+      REPO_NAME: ${{ github.repository }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get Environment Variables
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref }}" -replace 'refs/tags/', ''
+          
+          "tag=$tag" | Out-File -Append -FilePath $Env:GITHUB_ENV
+
+      - name: Set Lowercase Repo Name
+        run: echo "REPO_NAME_LOWER=$(echo $REPO_NAME | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - name: Set up Docker
+        uses: docker/setup-buildx-action@v3
+        with:
+          install: 'true'
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish Web Service
-        run: docker build . -f .\GatherBuddy.Web\Dockerfile --build-arg SECRET_KEY=${{ secrets.GITHUB_TOKEN }} -t ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} --quiet
+        run: docker build . -f ./GatherBuddy.Web/Dockerfile --build-arg SECRET_KEY=${{ secrets.GITHUB_TOKEN }} -t ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} --quiet
 
       - name: Tag Docker Image
         run: docker tag ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} ghcr.io/${{ env.REPO_NAME_LOWER }}:latest
@@ -67,10 +92,3 @@ jobs:
         run: |
           docker push ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }}
           docker push ghcr.io/${{ env.REPO_NAME_LOWER }}:latest
-
-      - name: Publish Plugin
-        uses: softprops/action-gh-release@v2
-        with:
-          files: ./build/GatherbuddyReborn.zip
-          token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Split the `publish.yaml` workflow into distinct `Plugin` and `Web` jobs for better clarity and organization. Moved Docker setup and container registry login exclusively to the `Web` job. Updated the `Plugin` job to handle plugin publishing using `softprops/action-gh-release`.