### PR TITLE
Remove hardcoded API key and update build process.

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -36,7 +36,7 @@ jobs:
         run: dotnet restore Gatherbuddy/Gatherbuddy.csproj
 
       - name: Build Plugin
-        run: dotnet build --no-restore -c Release Gatherbuddy/Gatherbuddy.csproj -p:SecretKey=${{ secrets.GITHUB_TOKEN }} -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:PackageVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
+        run: dotnet build --no-restore -c Release Gatherbuddy/Gatherbuddy.csproj /p:SecretKey="${{ secrets.GITHUB_TOKEN }}" -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:PackageVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
 
       - name: Zip Plugin
         run: Compress-Archive -Path .\build\* -DestinationPath .\build\GatherbuddyReborn.zip

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 .vs/
 .idea/
+SecretKeys.generated.cs

--- a/GatherBuddy.SecretKeys/SecretKeys.generated.cs
+++ b/GatherBuddy.SecretKeys/SecretKeys.generated.cs
@@ -1,9 +1,0 @@
-using System;
-
-namespace GatherBuddy.Keys
-{
-    public static class SecretKeys
-    {
-        public static string ApiKey = "ghp_7bf8162c0dda421885645d6f51c4ce6bd7fa"; //NOT A REAL KEY, DEMO PURPOSES ONLY
-    }
-}

--- a/GatherBuddy.Web/GatherBuddy.Web.csproj
+++ b/GatherBuddy.Web/GatherBuddy.Web.csproj
@@ -19,5 +19,4 @@
       </PackageReference>
     </ItemGroup>
   
-
 </Project>

--- a/GatherBuddy.Web/Program.cs
+++ b/GatherBuddy.Web/Program.cs
@@ -33,8 +33,6 @@ public class Program
               | ForwardedHeaders.XForwardedProto;
         });
 
-
-
         var app = builder.Build();
 
         using (var scope = app.Services.CreateScope())


### PR DESCRIPTION
Deleted the `SecretKeys.generated.cs` file containing a hardcoded API key for security reasons and added it to `.gitignore`. Adjusted the build command in the GitHub Actions workflow to use proper syntax for secret injection. Minor formatting cleanup in other project files.