### PR TITLE
Update build process to include generated secret keys file

### DIFF
--- a/GatherBuddy.SecretKeys/GatherBuddy.SecretKeys.csproj
+++ b/GatherBuddy.SecretKeys/GatherBuddy.SecretKeys.csproj
@@ -9,13 +9,14 @@
     <ItemGroup>
         <Compile Remove="SecretKeys.template.cs"/>
         <None Include="SecretKeys.template.cs"/>
+        <Compile Include="SecretKeys.generated.cs" />
     </ItemGroup>
 
     <PropertyGroup>
         <SecretKey>ghp_7bf8162c0dda421885645d6f51c4ce6bd7fa</SecretKey>
     </PropertyGroup>
 
-    <Target Name="GenerateSecretKeys" BeforeTargets="BeforeCompile">
+    <Target Name="GenerateSecretKeys" BeforeTargets="BeforeBuild">
         <Copy
                 SourceFiles="SecretKeys.template.cs"
                 DestinationFiles="SecretKeys.generated.cs"


### PR DESCRIPTION
Changed the build process to include `SecretKeys.generated.cs` by modifying the project file. Adjusted the `GenerateSecretKeys` target to run before the build instead of before compile, ensuring the file is ready during the build phase.