### PR TITLE
Update secret key reference in publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -48,7 +48,7 @@ jobs:
         run: dotnet restore Gatherbuddy/Gatherbuddy.csproj
 
       - name: Build Plugin
-        run: dotnet build --no-restore -c Release Gatherbuddy/Gatherbuddy.csproj /p:SecretKey="${{ secrets.GITHUB_TOKEN }}" -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:PackageVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
+        run: dotnet build --no-restore -c Release Gatherbuddy/Gatherbuddy.csproj /p:SecretKey="${{ env.SECRET_KEY }}" -p:AssemblyVersion=${{ env.tag }} -p:FileVersion=${{ env.tag }} -p:PackageVersion=${{ env.tag }} -p:InformationalVersion=${{ env.tag }} --output .\build
 
       - name: Zip Plugin
         run: Compress-Archive -Path .\build\* -DestinationPath .\build\GatherbuddyReborn.zip
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Web Service
-        run: docker build . -f ./GatherBuddy.Web/Dockerfile --build-arg SECRET_KEY=${{ secrets.GITHUB_TOKEN }} -t ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} --quiet --load
+        run: docker build . -f ./GatherBuddy.Web/Dockerfile --build-arg SECRET_KEY=${{ env.SECRET_KEY }} -t ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} --quiet --load
 
       - name: Tag Docker Image
         run: docker tag ghcr.io/${{ env.REPO_NAME_LOWER }}:${{ env.tag }} ghcr.io/${{ env.REPO_NAME_LOWER }}:latest


### PR DESCRIPTION
Replaced `secrets.GITHUB_TOKEN` with `env.SECRET_KEY` in build and deployment steps to utilize the correct secret environment variable. This ensures consistency and proper usage of the defined environment secrets.