### PR TITLE
Allow mounting up while moving

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -9,6 +9,7 @@ namespace GatherBuddy.AutoGather
     {
         public float                           MountUpDistance               { get; set; } = 15.0f;
         public uint                            AutoGatherMountId             { get; set; } = 1;
+        public bool MoveWhileMounting { get; set; } = false;
         public Dictionary<uint, List<Vector3>> BlacklistedNodesByTerritoryId { get; set; } = new();
 
         [Obsolete] public ActionConfig BYIIConfig    { get; set; } = new(true, 100, uint.MaxValue, new ActionConditions(), new Dictionary<string, object> { { "UseWithCystals", false }, { "MinimumIncrease", 1 } });

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -217,6 +217,12 @@ public partial class Interface
             ImGuiUtil.HoverTooltip("The distance at which you will mount up to move to a node.");
         }
 
+        public static void DrawMoveWhileMounting()
+        => DrawCheckbox("Move while mounting up",
+                "Begin pathfinding to the next node while summoning a mount",
+                GatherBuddy.Config.AutoGatherConfig.MoveWhileMounting,
+                b => GatherBuddy.Config.AutoGatherConfig.MoveWhileMounting = b);
+
         public static void DrawAntiStuckCooldown()
         {
             var tmp = GatherBuddy.Config.AutoGatherConfig.NavResetCooldown;
@@ -752,6 +758,7 @@ public partial class Interface
                 ConfigFunctions.DrawHonkVolumeSlider();
                 AutoGatherUI.DrawMountSelector();
                 ConfigFunctions.DrawMountUpDistance();
+                ConfigFunctions.DrawMoveWhileMounting();
                 ConfigFunctions.DrawSortingMethodCombo();
                 ConfigFunctions.DrawUseGivingLandOnCooldown();
                 ConfigFunctions.DrawGoHomeBox();


### PR DESCRIPTION
As of version 7.2 of the game, players can move while summoning their mount. This allows users to save entire moments of time with a mere double the pathfinding overhead.