### PR TITLE
Fix collectibles getting abandoned during revist

### DIFF
--- a/GatherBuddy/AutoGather/AtkReaders/GatheringMasterpieceReader.cs
+++ b/GatherBuddy/AutoGather/AtkReaders/GatheringMasterpieceReader.cs
@@ -1,0 +1,35 @@
+using ECommons.UIHelpers;
+using ECommons.UIHelpers.AddonMasterImplementations;
+using FFXIVClientStructs.FFXIV.Component.GUI;
+using GatherBuddy.Classes;
+
+namespace GatherBuddy.AutoGather.AtkReaders;
+
+// NOTE: Rewritten to use AtkReader (value-based) so it remains valid when the window is recreated by Revisit. 
+
+public unsafe class GatheringMasterpieceReader(AtkUnitBase* addon) : AtkReader(addon)
+{
+    private uint ItemId => ReadUInt(2).GetValueOrDefault();
+    public  Gatherable Item => GatherBuddy.GameData.Gatherables[ItemId];
+    public bool HighVisible
+        => addon->GetNodeById(15)->IsVisible();
+    public bool MidVisible => addon->GetNodeById(14)->IsVisible();
+    public bool LowVisible => addon->GetNodeById(13)->IsVisible();
+    public int  CollectabilityCurrent => (int)(ReadUInt(13) ?? 0);
+    public int  CollectabilityMax     => (int)(ReadUInt(14) ?? 0);
+
+    public int IntegrityCurrent => (int)(ReadUInt(62) ?? 0u);
+    public int IntegrityMax     => (int)(ReadUInt(63) ?? 0u);
+
+    public int ScourGain      => (int)(ReadUInt(48) ?? 0);
+    public int BrazenGainMin  => (int)(ReadUInt(49) ?? 0);
+    public int BrazenGainMax  => (int)(ReadUInt(50) ?? 0);
+    public int MeticulousGain => (int)(ReadUInt(51) ?? 0);
+
+    public int LowThreshold  => (int)(ReadUInt(65) ?? 0u);
+    public int MidThreshold  => (int)(ReadUInt(66) ?? 0u);
+    public int HighThreshold => (int)(ReadUInt(67) ?? 0u);
+
+    public bool IsValid => !IsNull;
+}
+

--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -112,7 +112,7 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void DoActionTasks(IEnumerable<GatherTarget> target)
         {
-            if (MasterpieceAddon != null)
+            if (MasterpieceReader?.IsValid == true)
             {
                 if (CurrentCollectableRotation == null)
                 {
@@ -481,38 +481,18 @@ namespace GatherBuddy.AutoGather
 
         private unsafe void DoCollectibles()
         {
-            if (MasterpieceAddon == null || CurrentCollectableRotation == null)
+            if (MasterpieceReader?.IsValid != true || CurrentCollectableRotation == null)
                 return;
 
-            var textNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(6);
-            if (textNode == null)
-                return;
+            int collectibility = MasterpieceReader.CollectabilityCurrent;
+            int integrity = MasterpieceReader.IntegrityCurrent;
 
-            var text = textNode->NodeText.ToString();
-
-            var integrityNode = MasterpieceAddon->AtkUnitBase.GetTextNodeById(126);
-            if (integrityNode == null)
-                return;
-
-            var integrityText = integrityNode->NodeText.ToString();
-
-            if (!int.TryParse(text, out var collectibility))
-            {
-                collectibility = 99999; // default value
-            }
-
-            if (!int.TryParse(integrityText, out var integrity))
-            {
-                collectibility = 99999;
-                integrity      = 99999;
-            }
-
-            if (collectibility < 99999)
+            if (integrity > 0)
             {
                 LastCollectability = collectibility;
                 LastIntegrity      = integrity;
 
-                var collectibleAction = CurrentCollectableRotation.GetNextAction(MasterpieceAddon);
+                var collectibleAction = CurrentCollectableRotation.GetNextAction(MasterpieceReader);
 
                 EnqueueActionWithDelay(() => UseAction(collectibleAction));
             }

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -53,7 +53,14 @@ namespace GatherBuddy.AutoGather
         public bool LureSuccess { get; private set; } = false;
 
         public unsafe GatheringReader? GatheringWindowReader
-            => GenericHelpers.TryGetAddonByName("Gathering", out AtkUnitBase* addon) ? new GatheringReader(addon) : null;
+            => GenericHelpers.TryGetAddonByName("Gathering", out AtkUnitBase* addon)
+                ? new GatheringReader(addon)
+                : null;
+
+        public unsafe GatheringMasterpieceReader? MasterpieceReader
+            => GenericHelpers.TryGetAddonByName("GatheringMasterpiece", out AtkUnitBase* add)
+                ? new GatheringMasterpieceReader(add)
+                : null;
 
         public static IReadOnlyList<InventoryType> InventoryTypes { get; } =
         [


### PR DESCRIPTION
Replaced direct `AddonGatheringMasterpiece` handling with the new `GatheringMasterpieceReader` to improve readability and consistency. Updated collectable action logic, reward tier checks, and related calculations to utilize the reader interface. Simplified target score and collectability management.