### PR TITLE
Added right click to Auto Gather window to toggle main plugin interface.

### DIFF
--- a/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
+++ b/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
@@ -313,8 +313,12 @@ public class GatherWindow : Window
         {
             GatherBuddy.AutoGather.Enabled = !GatherBuddy.AutoGather.Enabled;
         }
+        if (ImGui.IsItemClicked(ImGuiMouseButton.Right))
+        {
+            _plugin.Interface.Toggle();
+        }
         color.Pop();
-        ImGuiUtil.HoverTooltip("Click to enable/disable auto-gather");
+        ImGuiUtil.HoverTooltip("Click to enable/disable auto-gather. Right click to toggle interface");
         using var table = ImRaii.Table("##table", GatherBuddy.Config.ShowGatherWindowTimers ? 2 : 1);
         if (!table)
             return;


### PR DESCRIPTION
- Right clicking on Auto Gather window now toggles the plugin interface.
- Updated tooltip to match new functionality.
- Tested in local, works as expected.