### PR TITLE
Config Protection

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Actions.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Actions.cs
@@ -176,10 +176,13 @@ namespace GatherBuddy.AutoGather
             var state  = GatherBuddy.EventFramework.FishingState;
             var config = MatchConfigPreset(targets.First(t => t.Fish != null).Fish!);
             
-            if (DoUseConsumablesWithoutCastTime(config, true))
+            if (!GatherBuddy.Config.AutoGatherConfig.UseAutoHook || !AutoHook.Enabled)
             {
-                TaskManager.DelayNext(1000);
-                return;
+                if (DoUseConsumablesWithoutCastTime(config, true))
+                {
+                    TaskManager.DelayNext(1000);
+                    return;
+                }
             }
 
             if (EzThrottler.Throttle("GBR Fishing", 500))
@@ -257,6 +260,7 @@ namespace GatherBuddy.AutoGather
 
             if (GatherBuddy.Config.AutoGatherConfig.UseAutoHook && AutoHook.Enabled)
             {
+                TaskManager.DelayNext(2000);
                 EnqueueActionWithDelay(() => UseAction(Actions.Cast));
                 return;
             }
@@ -371,6 +375,12 @@ namespace GatherBuddy.AutoGather
         {
             if (GatheringWindowReader == null)
                 return;
+
+            if (LastIntegrity > 0 && GatheringWindowReader.IntegrityRemaining > LastIntegrity + 1)
+            {
+                ActionSequence = null;
+            }
+            LastIntegrity = GatheringWindowReader.IntegrityRemaining;
 
             foreach (var t in target)
             {

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -184,6 +184,7 @@ namespace GatherBuddy.AutoGather
         private uint _lastTerritory = 0;
         
         private uint _lastNonTimedNodeTerritory = 0;
+        private GatheringType _lastJob = GatheringType.Unknown;
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
 

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -32,6 +32,7 @@ namespace GatherBuddy.AutoGather.Lists
         private          uint                                    _lastTerritoryId;
         private          bool                                    _activeItemsChanged;
         private          bool                                    _gatheredSomething;
+        private          GatheringType                           _lastJob            = GatheringType.Unknown;
 
         internal ReadOnlyDictionary<GatheringNode, TimeInterval> DebugVisitedTimedLocations
             => _visitedTimedNodes.AsReadOnly();
@@ -443,9 +444,18 @@ namespace GatherBuddy.AutoGather.Lists
         /// </returns>
         private bool IsUpdateNeeded()
         {
+            var currentJob = Player.Job switch
+            {
+                Job.MIN => GatheringType.Miner,
+                Job.BTN => GatheringType.Botanist,
+                Job.FSH => GatheringType.Fisher,
+                _ => GatheringType.Unknown
+            };
+            
             if (_activeItemsChanged
              || _lastUpdateTime.TotalEorzeaHours() != AutoGather.AdjustedServerTime.TotalEorzeaHours()
-             || _lastTerritoryId != Dalamud.ClientState.TerritoryType)
+             || _lastTerritoryId != Dalamud.ClientState.TerritoryType
+             || _lastJob != currentJob)
                 return true;
 
             if (_gatheredSomething)
@@ -477,11 +487,19 @@ namespace GatherBuddy.AutoGather.Lists
             var eorzeaHour         = adjustedServerTime.TotalEorzeaHours();
             var lastTerritoryId    = _lastTerritoryId;
             var lastEorzeaHour     = _lastUpdateTime.TotalEorzeaHours();
+            var currentJob = Player.Job switch
+            {
+                Job.MIN => GatheringType.Miner,
+                Job.BTN => GatheringType.Botanist,
+                Job.FSH => GatheringType.Fisher,
+                _ => GatheringType.Unknown
+            };
 
             _activeItemsChanged = false;
             _gatheredSomething  = false;
             _lastUpdateTime     = adjustedServerTime;
             _lastTerritoryId    = territoryId;
+            _lastJob            = currentJob;
 
             if (territoryId != lastTerritoryId)
                 UpdateTeleportationCosts();

--- a/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
@@ -45,6 +45,7 @@ public class AutoGatherList
             items              = new(items),
             quantities         = new(quantities),
             preferredLocations = new(preferredLocations),
+            enabledItems       = new(enabledItems),
             Name               = Name,
             Description        = Description,
             FolderPath         = FolderPath,

--- a/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigPresetsTab.cs
@@ -159,17 +159,27 @@ namespace GatherBuddy.Gui
                 else
                 {
                     //Convert old settings to the new Default preset
-                    Items.Add(GatherBuddy.Config.AutoGatherConfig.ConvertToPreset());
-                    Items[0].ChooseBestActionsAutomatically = true;
-                    Save();
-                    GatherBuddy.Config.AutoGatherConfig.ConfigConversionFixed        = true;
-                    GatherBuddy.Config.AutoGatherConfig.RotationSolverConversionDone = true;
-                    GatherBuddy.Config.Save();
+                    if (GatherBuddy.Config.AutoGatherConfig != null)
+                    {
+                        Items.Add(GatherBuddy.Config.AutoGatherConfig.ConvertToPreset());
+                        Items[0].ChooseBestActionsAutomatically = true;
+                        Save();
+                        GatherBuddy.Config.AutoGatherConfig.ConfigConversionFixed        = true;
+                        GatherBuddy.Config.AutoGatherConfig.RotationSolverConversionDone = true;
+                        GatherBuddy.Config.Save();
+                    }
+                    else
+                    {
+                        Items.Add(new ConfigPreset { Name = "Default" });
+                    }
                 }
 
-                Items[Items.Count - 1] = Items[Items.Count - 1].MakeDefault();
+                if (Items.Count > 0)
+                {
+                    Items[Items.Count - 1] = Items[Items.Count - 1].MakeDefault();
+                }
 
-                if (!GatherBuddy.Config.AutoGatherConfig.RotationSolverConversionDone)
+                if (GatherBuddy.Config.AutoGatherConfig != null && !GatherBuddy.Config.AutoGatherConfig.RotationSolverConversionDone && Items.Count > 0)
                 {
                     Items[Items.Count - 1].ChooseBestActionsAutomatically            = true;
                     GatherBuddy.Config.AutoGatherConfig.RotationSolverConversionDone = true;
@@ -177,7 +187,7 @@ namespace GatherBuddy.Gui
                     GatherBuddy.Config.Save();
                 }
 
-                if (!GatherBuddy.Config.AutoGatherConfig.ConfigConversionFixed)
+                if (GatherBuddy.Config.AutoGatherConfig != null && !GatherBuddy.Config.AutoGatherConfig.ConfigConversionFixed && Items.Count > 0)
                 {
                     var def = Items[Items.Count - 1];
                     fixAction(def.GatherableActions.Bountiful);


### PR DESCRIPTION
Config fallbacks for possible config wipe with testing coming to release. 
FishingSpot Debug Tab data count column.
Reintroduce Location item sorting.
Fix duplicate list bug.
Turn off Quick Gathering when start auto-gather.