### PR TITLE
IPC Getters

### DIFF
--- a/GatherBuddy.GameData/Data/Fish/Data7.0.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data7.0.cs
@@ -41,13 +41,13 @@ public static partial class Fish
             .Bait(data, 43850)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43675, Patch.Dawntrail) // Sea Alpaca
-            .Bait(data, 29717)
+            .Bait(data, 43851)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(43676, Patch.Dawntrail) // Marbled Hatchetfish
-            .Bait(data, 29717)
+            .Bait(data, 43851)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(43677, Patch.Dawntrail) // Starsnipper
-            .Bait(data, 29717)
+            .Bait(data, 43851)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(43678, Patch.Dawntrail) // Urqotrout
             .Bait(data, 43851)
@@ -82,7 +82,7 @@ public static partial class Fish
             .Bait(data, 43852)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43688, Patch.Dawntrail) // Deepwarden
-            .Bait(data, 29717)
+            .Bait(data, 43858)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43689, Patch.Dawntrail) // Kozama'uka Skipper
             .Bait(data, 43852)
@@ -330,7 +330,7 @@ public static partial class Fish
             .Bait(data, 29717)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43769, Patch.Dawntrail) // Moon Croppie
-            .Bait(data, 29717)
+            .Bait(data, 43855)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43770, Patch.Dawntrail) // Driftdowns Trout
             .Bait(data, 29717)
@@ -352,16 +352,16 @@ public static partial class Fish
             .Bite(data, HookSet.Powerful, BiteType.Strong)
             .Lure(Enums.Lure.Ambitious);
         data.Apply(43776, Patch.Dawntrail) // Everkeep Yabby
-            .Bait(data, 29717)
+            .Bait(data, 43858)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(43777, Patch.Dawntrail) // Stickleback
-            .Bait(data, 29717)
+            .Bait(data, 43858)
             .Bite(data, HookSet.Precise, BiteType.Weak);
         data.Apply(43778, Patch.Dawntrail) // Custodian Carp
-            .Bait(data, 29717)
+            .Bait(data, 43858)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43779, Patch.Dawntrail) // Mosaic Loach
-            .Bait(data, 29717)
+            .Bait(data, 43858)
             .Bite(data, HookSet.Powerful, BiteType.Strong);
         data.Apply(43780, Patch.Dawntrail) // Rosebud Frog
             .Bait(data, 29717)

--- a/GatherBuddy/AutoGather/AutoGather.AutoHook.cs
+++ b/GatherBuddy/AutoGather/AutoGather.AutoHook.cs
@@ -56,6 +56,7 @@ public partial class AutoGather
             else
             {
                 AutoHook.SetPluginState?.Invoke(true);
+                AutoHook.SetAutoStartFishing?.Invoke(true); 
             }
             Svc.Log.Verbose($"[AutoGather] Re-enabled existing AutoHook preset '{_currentAutoHookPresetName}'");
             return;

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -92,6 +92,7 @@ namespace GatherBuddy.AutoGather
         public bool EnableIdenticalCast { get; set; } = false;
         public int IdenticalCastGPThreshold { get; set; } = 350;
         public bool IdenticalCastGPAbove { get; set; } = true;
+        public bool UseHookTimers { get; set; } = false;
         public bool AutoCollectablesFishing { get; set; } = true;
         public bool DiademAutoAetherCannon { get; set; } = false;
 

--- a/GatherBuddy/AutoGather/AutoGather.Gather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Gather.cs
@@ -25,7 +25,11 @@ namespace GatherBuddy.AutoGather
             if (targetSystem == null)
                 return;
 
-            TaskManager.Enqueue(() => targetSystem->OpenObjectInteraction((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)gameObject.Address));
+            TaskManager.Enqueue(() =>
+            {
+                _lastNodeInteractionTime = Environment.TickCount64;
+                targetSystem->OpenObjectInteraction((FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)gameObject.Address);
+            });
             TaskManager.Enqueue(() => Dalamud.Conditions[ConditionFlag.Gathering], 500);
             
             TaskManager.Enqueue(() => {

--- a/GatherBuddy/AutoGather/AutoGather.Movement.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Movement.cs
@@ -419,6 +419,19 @@ namespace GatherBuddy.AutoGather
                 return false;
             }
 
+            if (Svc.Condition[ConditionFlag.Occupied]
+             || Svc.Condition[ConditionFlag.Gathering]
+             || Svc.Condition[ConditionFlag.ExecutingGatheringAction]
+             || Svc.Condition[ConditionFlag.Fishing]
+             || Svc.Condition[ConditionFlag.Casting]
+             || Svc.Condition[ConditionFlag.Mounting]
+             || Svc.Condition[ConditionFlag.Mounting71]
+             || Environment.TickCount64 - _lastNodeInteractionTime < 2000)
+            {
+                GatherBuddy.Log.Debug($"[MoveToTerritory] Cannot teleport in current state, deferring teleport");
+                return false;
+            }
+
             EnqueueActionWithDelay(() => Teleporter.Teleport(aetheryte.Id));
             TaskManager.Enqueue(() => Svc.Condition[ConditionFlag.BetweenAreas]);
             TaskManager.Enqueue(() => !Svc.Condition[ConditionFlag.BetweenAreas]);

--- a/GatherBuddy/AutoGather/AutoGather.Var.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Var.cs
@@ -194,6 +194,7 @@ namespace GatherBuddy.AutoGather
         private bool _wasAtShadowNode = false;
 
         private IEnumerator<Actions.BaseAction?>? ActionSequence;
+        private long _lastNodeInteractionTime = 0;
 
         private static unsafe T* GetAddon<T>(string name) where T : unmanaged
         {

--- a/GatherBuddy/AutoHookIntegration/AutoHookPresetBuilder.cs
+++ b/GatherBuddy/AutoHookIntegration/AutoHookPresetBuilder.cs
@@ -305,7 +305,7 @@ public class AutoHookPresetBuilder
         tripleConfig!.HooksetEnabled = true;
         tripleConfig.HooksetType = hookType;
 
-        if (minTime > 0 || maxTime > 0)
+        if (GatherBuddy.Config.AutoGatherConfig.UseHookTimers && (minTime > 0 || maxTime > 0))
         {
             patienceConfig.HookTimerEnabled = true;
             patienceConfig.MinHookTimer = minTime;

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -218,16 +218,27 @@ public partial class Interface
 
                     foreach (var (itemName, quantity) in items)
                     {
-                        var gatherable =
-                            GatherBuddy.GameData.Gatherables.Values.FirstOrDefault(g => g.Name[Dalamud.ClientState.ClientLanguage] == itemName);
-                        if (gatherable == null || (gatherable.NodeList.Count == 0 
-                            && !UmbralNodes.IsUmbralItem(gatherable.ItemId) 
-                            && !(gatherable.NodeList.Any(n => n.Territory.Id is 901 or 929 or 939)
-                                && (gatherable.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 4")
-                                    || (gatherable.Name[Dalamud.ClientState.ClientLanguage].Contains("Artisanal")
-                                        && (gatherable.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 2") 
-                                            || gatherable.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 3")))))))
-                            continue;
+                        var gatherableItem = GatherBuddy.GameData.Gatherables.Values.FirstOrDefault(g => g.Name[Dalamud.ClientState.ClientLanguage] == itemName);
+                        IGatherable? gatherable = gatherableItem;
+                        
+                        if (gatherableItem != null)
+                        {
+                            if (gatherableItem.NodeList.Count == 0 
+                                && !UmbralNodes.IsUmbralItem(gatherableItem.ItemId) 
+                                && !(gatherableItem.NodeList.Any(n => n.Territory.Id is 901 or 929 or 939)
+                                    && (gatherableItem.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 4")
+                                        || (gatherableItem.Name[Dalamud.ClientState.ClientLanguage].Contains("Artisanal")
+                                            && (gatherableItem.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 2") 
+                                                || gatherableItem.Name[Dalamud.ClientState.ClientLanguage].Contains("Grade 3"))))))
+                                continue;
+                        }
+                        else
+                        {
+                            gatherable = GatherBuddy.GameData.Fishes.Values.FirstOrDefault(f => f.Name[Dalamud.ClientState.ClientLanguage] == itemName);
+                            
+                            if (gatherable == null)
+                                continue;
+                        }
 
                         list.Add(gatherable, (uint)quantity);
                     }

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -941,6 +941,16 @@ public partial class Interface
             }
         }
 
+        public static void DrawUseHookTimersBox()
+        {
+            DrawCheckbox("Use Hook Timers in AutoHook Presets",
+                "Enable bite timer windows in generated AutoHook presets.",
+                GatherBuddy.Config.AutoGatherConfig.UseHookTimers,
+                b => GatherBuddy.Config.AutoGatherConfig.UseHookTimers = b);
+            ImGui.SameLine();
+            ImGuiEx.PluginAvailabilityIndicator([new("AutoHook")]);
+        }
+
         public static void DrawAutoCollectablesFishingBox()
             => DrawCheckbox("Auto Collectables",
                 "Auto accept/decline collectable fish based on minimum collectability.",
@@ -1071,6 +1081,7 @@ public partial class Interface
                 ConfigFunctions.DrawFishingSpotMinutes();
                 ConfigFunctions.DrawFishCollectionBox();
                 ConfigFunctions.DrawAutoCollectablesFishingBox();
+                ConfigFunctions.DrawUseHookTimersBox();
                 ConfigFunctions.DrawSurfaceSlapConfig();
                 ConfigFunctions.DrawIdenticalCastConfig();
                 ConfigFunctions.DrawManualPresetGenerator();

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -264,6 +264,12 @@ namespace GatherBuddy.Plugin
 
         internal static bool Enabled => IPCSubscriber.IsReady("AutoHook");
 
+        [EzIPC("AutoHook.GetPluginState", applyPrefix: false)]
+        internal static readonly Func<bool> GetPluginState;
+
+        [EzIPC("AutoHook.GetAutoStartFishing", applyPrefix: false)]
+        internal static readonly Func<bool> GetAutoStartFishing;
+
         [EzIPC("AutoHook.SetPluginState", applyPrefix: false)]
         internal static readonly Action<bool> SetPluginState;
 


### PR DESCRIPTION
Add IPC for status getters for AutoHook. Fixes IPC missfiring on many actions. 
Hook Timer usage added to Fishing config. Defaulted OFF 
Support for AutoGather window showing fish with dependencies mirroring Fish Tab 
TeamCraft import now supports fish.
Fish with dependency fish now take into account predator fish timers in addition to target fish timer.