### PR TITLE
Fish timer

### DIFF
--- a/GatherBuddy.GameData/Data/Fish/Data3.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data3.5.cs
@@ -104,7 +104,7 @@ public static partial class Fish
             .Predators (data, 180, (12800, 3), (12754, 5))
             .Weather   (data, 1, 2);
         data.Apply     (17589, Patch.TheFarEdgeOfFate) // Opabinia
-            .Mooch     (data, 30136, 12776)
+            .Mooch     (data, 12710, 12776)
             .Bite      (data, HookSet.Precise, BiteType.Legendary)
             .ForceLegendary()
             .Snag      (data, Snagging.None)

--- a/GatherBuddy.GameData/Data/Fish/Data4.0.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data4.0.cs
@@ -161,7 +161,7 @@ public static partial class Fish
             .Bait      (data, 20614)
             .Bite      (data, HookSet.Precise, BiteType.Weak);
         data.Apply     (20064, Patch.Stormblood) // Balloon Frog
-            .Bait      (data, 20614)
+            .Bait      (data, 20613)
             .Bite      (data, HookSet.Precise, BiteType.Weak)
             .Snag      (data, Snagging.None);
         data.Apply     (20065, Patch.Stormblood) // Lantern Marimo

--- a/GatherBuddy.GameData/Data/Fish/Data6.0.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.0.cs
@@ -287,7 +287,7 @@ public static partial class Fish
             .Bait      (data, 36594)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (36489, Patch.Endwalker) // Vacuum Shrimp
-            .Bait      (data, 36594)
+            .Bait      (data, 36595)
             .Bite      (data, HookSet.Powerful, BiteType.Strong);
         data.Apply     (36491, Patch.Endwalker) // Cosmic Noise
             .Bait      (data, 36594)

--- a/GatherBuddy.GameData/Data/Fish/Data6.3.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.3.cs
@@ -48,7 +48,7 @@ public static partial class Fish
             .Weather(data, 49)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(38835, Patch.GodsRevelLandsTremble) // Cosmic Haze
-            .Mooch(data, 36594, 36489)
+            .Mooch(data, 36595, 36489)
             .Time(1200, 240)
             .Weather(data, 149)
             .Bite(data, HookSet.Powerful, BiteType.Legendary);

--- a/GatherBuddy.GameData/Data/Fish/Data6.5.cs
+++ b/GatherBuddy.GameData/Data/Fish/Data6.5.cs
@@ -56,7 +56,7 @@ public static partial class Fish
             .Time(720, 960)
             .Transition(data, 2)
             .Weather(data, 49)
-            .Bite(data, HookSet.Unknown, BiteType.Legendary);
+            .Bite(data, HookSet.Powerful, BiteType.Legendary);
         data.Apply(41419, Patch.GrowingLight) // Stargilt Lobster
             .Bait(data, 36594)
             .Time(1140, 1320)

--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -82,7 +82,7 @@ namespace GatherBuddy.AutoGather
         public int SoundPlaybackVolume { get; set; } = 100;
         public bool FishDataCollection { get; set; } = false;
         public bool AlwaysGatherMaps { get; set; } = false;
-        public int MaxFishingSpotMinutes { get; set; } = 20;
+        public int MaxFishingSpotMinutes { get; set; } = 0;
         public bool UseNavigation { get; set; } = true;
         public bool UseAutoHook { get; set; } = true;
         public bool DisableAutoHookOnStop { get; set; } = false;

--- a/GatherBuddy/GatherBuddy.Commands.cs
+++ b/GatherBuddy/GatherBuddy.Commands.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
+using Dalamud.Game;
 using Dalamud.Game.Command;
 using Dalamud.Game.Text.SeStringHandling;
 using GatherBuddy.Enums;
@@ -231,6 +232,43 @@ public partial class GatherBuddy
 
     private static void OnGatherDebug(string command, string arguments)
     {
-        DebugMode = !DebugMode;
+        switch (arguments.ToLowerInvariant())
+        {
+            case "wary":
+                Dalamud.ToastGui.ShowQuest("The fish have become wary of your presence. It might be time to shift your position...");
+                Communicator.Print("Debug: Triggered 'wary' quest toast [EN] (ID 5517)");
+                break;
+            case "amiss":
+                Dalamud.ToastGui.ShowQuest("The fish sense something amiss. Perhaps it is time to try another location.");
+                Communicator.Print("Debug: Triggered 'amiss' quest toast [EN] (ID 3516)");
+                break;
+            case "wary-de":
+                Dalamud.ToastGui.ShowQuest("Die Fische in der Umgebung sind auf dich aufmerksam geworden. Besser, du wechselst den Ort ...");
+                Communicator.Print("Debug: Triggered 'wary' quest toast [DE] (ID 5517)");
+                break;
+            case "amiss-de":
+                Dalamud.ToastGui.ShowQuest("Die Fische sind misstrauisch und kommen keinen Ilm näher. Versuch es lieber an einer anderen Stelle.");
+                Communicator.Print("Debug: Triggered 'amiss' quest toast [DE] (ID 3516)");
+                break;
+            case "wary-fr":
+                Dalamud.ToastGui.ShowQuest("Les poissons des environs commencent à se méfier de vous. Il est temps d'aller voir ailleurs...");
+                Communicator.Print("Debug: Triggered 'wary' quest toast [FR] (ID 5517)");
+                break;
+            case "amiss-fr":
+                Dalamud.ToastGui.ShowQuest("Les poissons sont devenus méfiants. Vous devriez aller pêcher dans un autre endroit.");
+                Communicator.Print("Debug: Triggered 'amiss' quest toast [FR] (ID 3516)");
+                break;
+            case "wary-jp":
+                Dalamud.ToastGui.ShowQuest("周辺の魚が警戒し始めている。そろそろ移動した方が良さそうだ……");
+                Communicator.Print("Debug: Triggered 'wary' quest toast [JP] (ID 5517)");
+                break;
+            case "amiss-jp":
+                Dalamud.ToastGui.ShowQuest("魚たちに警戒されてしまったようだ……。少し場所を変えたほうがいいだろう。");
+                Communicator.Print("Debug: Triggered 'amiss' quest toast [JP] (ID 3516)");
+                break;
+            default:
+                DebugMode = !DebugMode;
+                break;
+        }
     }
 }


### PR DESCRIPTION
Various Fish.Data corrections.
New Wary/Amiss detection. [@Luna](https://github.com/Luna) for help with initial fix and footwork.
Now uses Toast reading to detect Wary/Amiss. All client support.
Bug fix for timed fish not being detected as caught.
Bug fix for moving within the same fishingspot when multiple are in the same spot.
Mooch dependency added for determining if a fish should be targetted.
Adjust perception checking to accomodate being on a non-gathering or fisher job. Now also on enabling auto-gather to catch derps.
Preset Generator overhaul for mooch/surfaceslap/and various redundant settings that cannot even apply to mooch chains.