### PR TITLE
feat: Add scrip reserve option for collectable purchases

### DIFF
--- a/GatherBuddy/AutoGather/Collectables/CollectableManager.cs
+++ b/GatherBuddy/AutoGather/Collectables/CollectableManager.cs
@@ -781,11 +781,17 @@ public class CollectableManager : IDisposable
         
         var next = _purchaseQueue.Peek();
         var scrips = _scripShopWindowHandler.GetScripCount();
-        var maxByScrip = next.cost > 0 ? (scrips / next.cost) : next.remaining;
+        var reserveAmount = _config.CollectableConfig.ReserveScripAmount;
+        var availableScrips = Math.Max(0, scrips - reserveAmount);
+        var maxByScrip = next.cost > 0 ? (availableScrips / next.cost) : next.remaining;
         var amount = Math.Min(next.remaining, Math.Min(maxByScrip, 99));
         
         if (amount <= 0)
         {
+            if (reserveAmount > 0 && scrips < reserveAmount + next.cost)
+            {
+                GatherBuddy.Log.Information($"[CollectableManager] Skipping purchase of {next.name} - would exceed scrip reserve (Current: {scrips}, Reserve: {reserveAmount}, Cost: {next.cost})");
+            }
             _purchaseQueue.Dequeue();
             _state = CollectableState.CheckingForMorePurchases;
             return;

--- a/GatherBuddy/Config/CollectableConfig.cs
+++ b/GatherBuddy/Config/CollectableConfig.cs
@@ -12,6 +12,7 @@ public class CollectableConfig
     public bool UseInventoryFullThreshold { get; set; } = false;
     public int CollectableInventoryThreshold { get; set; } = 100;
     public int InventoryFullThreshold { get; set; } = 140;
+    public int ReserveScripAmount { get; set; } = 0;
     
     private CollectableShop? _preferredCollectableShop;
     

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -1341,6 +1341,18 @@ public partial class Interface
                 GatherBuddy.Config.CollectableConfig.BuyAfterEachCollect,
                 b => GatherBuddy.Config.CollectableConfig.BuyAfterEachCollect = b);
         
+        public static void DrawScripReserveAmount()
+        {
+            var reserveAmount = GatherBuddy.Config.CollectableConfig.ReserveScripAmount;
+            ImGui.SetNextItemWidth(150);
+            if (ImGui.DragInt("Reserve Scrips", ref reserveAmount, 10, 0, 4000))
+            {
+                GatherBuddy.Config.CollectableConfig.ReserveScripAmount = Math.Max(0, Math.Min(4000, reserveAmount));
+                GatherBuddy.Config.Save();
+            }
+            ImGuiUtil.HoverTooltip("Minimum amount of scrips to keep when purchasing items from the scrip shop.\nPurchases will stop if buying would bring your scrips below this amount.");
+        }
+        
         public static void DrawScripShopItemManager()
         {
             var shopItems = ScripShopItemManager.ShopItems;
@@ -1631,6 +1643,10 @@ public partial class Interface
                     ConfigFunctions.DrawCollectableThreshold();
                 }
                 ConfigFunctions.DrawBuyAfterEachCollectBox();
+                if (GatherBuddy.Config.CollectableConfig.BuyAfterEachCollect)
+                {
+                    ConfigFunctions.DrawScripReserveAmount();
+                }
                 
                 ImGui.Spacing();
                 ImGui.Separator();


### PR DESCRIPTION
- Added ReserveScripAmount config property (default: 0, max: 4000)

- Added UI control in Collectable config section

- Updated purchase logic to respect scrip reserve threshold

- Added informative logging when purchases are skipped due to reserve

for discord pinned message: 

> Battler — 12/14/2025 3:14 PM
> an option to keep X amount of scrips would be a great start