### PR TITLE
Feature/add all filtered to autogather

### DIFF
--- a/GatherBuddy/Gui/Interface.ContextMenus.cs
+++ b/GatherBuddy/Gui/Interface.ContextMenus.cs
@@ -17,7 +17,8 @@ using GatherBuddy.GatherHelper;
 using GatherBuddy.Interfaces;
 using GatherBuddy.Plugin;
 using GatherBuddy.Structs;
-using ImRaii = ElliLib.Raii.ImRaii;
+using ElliLib.Table;
+using ImRaii  = ElliLib.Raii.ImRaii;
 
 namespace GatherBuddy.Gui;
 
@@ -228,6 +229,48 @@ public partial class Interface
         if (ImGui.IsItemHovered())
             ImGui.SetTooltip(
                 $"Add {item.Name[GatherBuddy.Language]} to {(current == null ? "a new gather window preset." : CheckUnnamed(current.Name))}");
+    }
+
+    private void DrawAddAllFilteredToAutoGather<T>(Table<T> table, Func<T, IGatherable> selector, string label)
+    {
+        var lists = _plugin.AutoGatherListsManager.Lists.ToList();
+        if (lists.Count == 0)
+            return;
+
+        var popupId = $"##AddAllFiltered{label}Popup";
+        if (ImGui.Button($"Add All Filtered {label} to Auto-Gather List..."))
+            ImGui.OpenPopup(popupId);
+
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip($"Add all currently visible {label.ToLowerInvariant()} to a selected auto-gather list.\n"
+              + "Items already present in the list are skipped.");
+
+        using var popup = ImRaii.Popup(popupId);
+        if (!popup)
+            return;
+
+        foreach (var list in lists)
+        {
+            if (!ImGui.Selectable(CheckUnnamed(list.Name)))
+                continue;
+
+            var added = 0;
+            foreach (var (row, _) in table.GetFilteredItems())
+            {
+                var item = selector(row);
+                if (!item.Locations.Any())
+                    continue;
+
+                if (list.Add(item))
+                    added++;
+            }
+
+            _plugin.AutoGatherListsManager.Save();
+            if (list.Enabled)
+                _plugin.AutoGatherListsManager.SetActiveItems();
+
+            GatherBuddy.Log.Information($"[GatherUI] Added {added} {label.ToLowerInvariant()} to auto-gather list '{list.Name}'.");
+        }
     }
 
     private static AutoGatherList CreateAndAddPreset(IGatherable item)

--- a/GatherBuddy/Gui/Interface.FishTab.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.cs
@@ -607,7 +607,8 @@ public partial class Interface
         if (!tab)
             return;
 
-        _fishTable.ExtraHeight = GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0;
+        _fishTable.ExtraHeight = (GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0)
+          + ImGui.GetFrameHeightWithSpacing();
         _fishTable.Draw(ImGui.GetTextLineHeightWithSpacing());
         DrawAddAllFilteredToAutoGather(_fishTable, f => f.Data, "Fish");
         DrawStatusLine(_fishTable, "Fish");

--- a/GatherBuddy/Gui/Interface.FishTab.cs
+++ b/GatherBuddy/Gui/Interface.FishTab.cs
@@ -609,6 +609,7 @@ public partial class Interface
 
         _fishTable.ExtraHeight = GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0;
         _fishTable.Draw(ImGui.GetTextLineHeightWithSpacing());
+        DrawAddAllFilteredToAutoGather(_fishTable, f => f.Data, "Fish");
         DrawStatusLine(_fishTable, "Fish");
         DrawClippy();
     }

--- a/GatherBuddy/Gui/Interface.ItemTab.cs
+++ b/GatherBuddy/Gui/Interface.ItemTab.cs
@@ -434,7 +434,8 @@ public partial class Interface
         if (!tab)
             return;
 
-        _itemTable.ExtraHeight = GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0;
+        _itemTable.ExtraHeight = (GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0)
+          + ImGui.GetFrameHeightWithSpacing();
         _itemTable.Draw(ImGui.GetTextLineHeightWithSpacing());
         DrawAddAllFilteredToAutoGather(_itemTable, g => g.Data, "Gatherables");
         DrawStatusLine(_itemTable, "Items");

--- a/GatherBuddy/Gui/Interface.ItemTab.cs
+++ b/GatherBuddy/Gui/Interface.ItemTab.cs
@@ -436,6 +436,7 @@ public partial class Interface
 
         _itemTable.ExtraHeight = GatherBuddy.Config.ShowStatusLine ? ImGui.GetTextLineHeight() : 0;
         _itemTable.Draw(ImGui.GetTextLineHeightWithSpacing());
+        DrawAddAllFilteredToAutoGather(_itemTable, g => g.Data, "Gatherables");
         DrawStatusLine(_itemTable, "Items");
         DrawClippy();
     }


### PR DESCRIPTION
Adds a button below the Fish and Gatherables tables that lets you bulk-add everything currently visible (after filters) to an auto-gather list in one click. Super handy if you want to queue up a whole category of fish or a filtered set of nodes without right-clicking each one individually.
Clicking the button opens a small popup listing your auto-gather lists — pick one and it'll add all the filtered items, skipping anything already in the list.

<img width="698" height="173" alt="image" src="https://github.com/user-attachments/assets/a52e5dd7-ef9d-405c-8682-1ab531e206c0" />

------------------
<img width="411" height="135" alt="image" src="https://github.com/user-attachments/assets/a686edc1-8f57-4d41-ae2f-24f236148060" />
