### PR TITLE
feat: add multi resources

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.Config.cs
+++ b/GatherBuddy/AutoGather/AutoGather.Config.cs
@@ -31,6 +31,7 @@ namespace GatherBuddy.AutoGather
         public bool HonkMode { get; set; } = true;
         public SortingType SortingMethod { get; set; } = SortingType.Location;
         public bool TeleportToNextNode { get; set; } = false;
+        public bool SplitGatherableForAllLocationsIfNoPreferenceSelected { get; set; } = false;
         public bool GoHomeWhenIdle { get; set; } = true;
         public bool GoHomeWhenDone { get; set; } = true;
         public bool UseSkillsForFallbackItems { get; set; } = false;

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -2299,7 +2299,7 @@ namespace GatherBuddy.AutoGather
                     return true;
                 }
                 
-                foreach (var (item, _) in listsManager.ActiveItems)
+                foreach (var (item, _, _) in listsManager.ActiveItems)
                 {
                     if (item is not Gatherable gatherable)
                         continue;

--- a/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
+++ b/GatherBuddy/AutoGather/Lists/ActiveItemList.cs
@@ -141,14 +141,14 @@ namespace GatherBuddy.AutoGather.Lists
                 _consumedCloudedNode = EnhancedCurrentWeather.GetCurrentWeatherId() == x.Node.UmbralWeather.Id;
         }
 
-        private bool NeedsGathering((IGatherable item, uint quantity) value)
+        private bool NeedsGathering((IGatherable item, uint quantity, ILocation? preferredLocation) value)
         {
-            var (item, quantity) = value;
+            var (item, quantity, _) = value;
             return item.GetTotalCount() < quantity && CheckOvercap(item);
         }
 
         private bool NeedsGathering(GatherTarget target)
-            => NeedsGathering((target.Item, target.Quantity));
+            => NeedsGathering((target.Item, target.Quantity, target.Location));
 
         private static bool CheckOvercap(IGatherable item)
         {
@@ -198,16 +198,14 @@ namespace GatherBuddy.AutoGather.Lists
             var targets = _listsManager.ActiveItems
                 // Filter out items that are already gathered.
                 .Where(NeedsGathering)
-                // Fetch preferred location.
-                .Select(x => (x.Item, x.Quantity, PreferredLocation: _listsManager.GetPreferredLocation(x.Item)))
                 // Flatten node list and calculate the next uptime.
-                .SelectMany(x => x.Item.Locations.Select(Location
-                    => (x.Item, Location, Time: Location switch
+                .SelectMany(x => x.Item.Locations.Select(location
+                    => (x.Item, Location: location, Time: location switch
                     {
                         GatheringNode node => node.Times.NextUptime(adjustedServerTime),
                         FishingSpot spot => GatherBuddy.UptimeManager.NextUptime((x.Item as Fish)!, spot.Territory, adjustedServerTime),
                         _ => throw new InvalidOperationException()
-                    }, x.Quantity, x.PreferredLocation)))
+                    }, x.Quantity, PreferredLocation: GetTargetPreferredLocation(x.Item, x.PreferredLocation, location))))
                 // If treasure map, only gather if the allowance is up.
                 .Select(x => x.Item.IsTreasureMap && (nextAllowance ??= DiscipleOfLand.NextTreasureMapAllowance) > adjustedServerTime.DateTime ? x with { Time = TimeInterval.Invalid } : x)
                 // Remove nodes that require the player to be on the home world.
@@ -225,8 +223,8 @@ namespace GatherBuddy.AutoGather.Lists
                 .Select(x => x with { Time = IntersectPredatorUptime(x.Item, x.Location, x.Time, adjustedServerTime) })
                 // Remove uptime for nodes that have already been gathered.
                 .Select(x => x.Location is GatheringNode node && _visitedTimedNodes.ContainsKey(node) ? x with { Time = TimeInterval.Invalid } : x)
-                // Group by item and select the best node.
-                .GroupBy(x => x.Item, x => x, (_, g) => g
+                // Select one best node per configured entry, or one node per location when no preference should expand.
+                .GroupBy(x => (x.Item, x.Quantity, x.PreferredLocation), x => x, (_, g) => g
                     // Prioritize active nodes
                     .OrderBy(x => !x.Time.InRange(adjustedServerTime))
                     // Prioritize preferred location, then current job, then preferred job, then the rest.
@@ -304,6 +302,17 @@ namespace GatherBuddy.AutoGather.Lists
             }
 
             GatherBuddy.Log.Verbose($"Gatherable items: ({_gatherableItems.Count}): {string.Join(", ", _gatherableItems.Select(x => x.Item.Name))}.");
+        }
+
+        private static ILocation? GetTargetPreferredLocation(IGatherable item, ILocation? preferredLocation, ILocation location)
+        {
+            if (preferredLocation != null)
+                return preferredLocation;
+
+            return GatherBuddy.Config.AutoGatherConfig.SplitGatherableForAllLocationsIfNoPreferenceSelected
+             && item.Locations.Count > 1
+                ? location
+                : null;
         }
 
         private ILocation CorrectForPredatorLocation(IGatherable item, ILocation location)

--- a/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherList.cs
@@ -15,17 +15,31 @@ namespace GatherBuddy.AutoGather.Lists;
 
 public class AutoGatherList
 {
+    public sealed class Entry
+    {
+        public required IGatherable Item { get; set; }
+        public uint Quantity { get; set; }
+        public ILocation? PreferredLocation { get; set; }
+        public bool Enabled { get; set; } = true;
+    }
+
+    public ReadOnlyCollection<Entry> Entries
+        => entries.AsReadOnly();
+
     public ReadOnlyCollection<IGatherable> Items
-        => items.AsReadOnly();
+        => entries.Select(e => e.Item).ToList().AsReadOnly();
 
     public ReadOnlyDictionary<IGatherable, uint> Quantities
-        => quantities.AsReadOnly();
+        => entries.GroupBy(e => e.Item).ToDictionary(g => g.Key, g => g.First().Quantity).AsReadOnly();
 
     public ReadOnlyDictionary<IGatherable, ILocation> PreferredLocations
-        => preferredLocations.AsReadOnly();
+        => entries.Where(e => e.PreferredLocation != null)
+            .GroupBy(e => e.Item)
+            .ToDictionary(g => g.Key, g => g.First().PreferredLocation!)
+            .AsReadOnly();
 
     public ReadOnlyDictionary<IGatherable, bool> EnabledItems
-        => enabledItems.AsReadOnly();
+        => entries.GroupBy(e => e.Item).ToDictionary(g => g.Key, g => g.First().Enabled).AsReadOnly();
 
     public string Name        { get; set; } = string.Empty;
     public string Description { get; set; } = string.Empty;
@@ -34,96 +48,86 @@ public class AutoGatherList
     public bool   Enabled     { get; set; } = false;
     public bool   Fallback    { get; set; } = false;
 
-    private List<IGatherable>                  items              = [];
-    private Dictionary<IGatherable, uint>      quantities         = [];
-    private Dictionary<IGatherable, ILocation> preferredLocations = [];
-    private Dictionary<IGatherable, bool>      enabledItems       = [];
+    private List<Entry> entries = [];
 
     public AutoGatherList Clone()
         => new()
         {
-            items              = new(items),
-            quantities         = new(quantities),
-            preferredLocations = new(preferredLocations),
-            enabledItems       = new(enabledItems),
-            Name               = Name,
-            Description        = Description,
-            FolderPath         = FolderPath,
-            Order              = Order,
-            Enabled            = false,
-            Fallback           = Fallback
+            entries = entries.Select(e => new Entry
+            {
+                Item = e.Item,
+                Quantity = e.Quantity,
+                PreferredLocation = e.PreferredLocation,
+                Enabled = e.Enabled,
+            }).ToList(),
+            Name        = Name,
+            Description = Description,
+            FolderPath  = FolderPath,
+            Order       = Order,
+            Enabled     = false,
+            Fallback    = Fallback,
         };
 
-    public bool Add(IGatherable item, uint quantity = 1)
+    public bool Add(IGatherable item, uint quantity = 1, ILocation? preferredLocation = null)
     {
-        if (quantities.ContainsKey(item))
+        if (entries.Any(e => e.Item == item && e.PreferredLocation == preferredLocation))
             return false;
 
-        items.Add(item);
-        quantities[item]   = NormalizeQuantity(item, quantity);
-        enabledItems[item] = true;
+        entries.Add(new Entry
+        {
+            Item = item,
+            Quantity = NormalizeQuantity(item, quantity),
+            PreferredLocation = preferredLocation,
+            Enabled = true,
+        });
         return true;
     }
 
     public void RemoveAt(int index)
-    {
-        var item = items[index];
-        enabledItems.Remove(item);
-        quantities.Remove(item);
-        preferredLocations.Remove(item);
-        items.RemoveAt(index);
-    }
+        => entries.RemoveAt(index);
 
     public bool Replace(int index, IGatherable item)
     {
-        if (quantities.ContainsKey(item))
+        var entry = entries[index];
+        if (entries.Where((_, i) => i != index).Any(e => e.Item == item && e.PreferredLocation == entry.PreferredLocation))
             return false;
 
-        var old = items[index];
-        quantities.Remove(old, out var quantity);
-        enabledItems.Remove(old, out var enabled);
-        if (old is Gatherable gatherable)
-            preferredLocations.Remove(gatherable);
-        items[index]       = item;
-        quantities[item]   = NormalizeQuantity(item, quantity);
-        enabledItems[item] = enabled;
+        entry.Item = item;
+        entry.Quantity = NormalizeQuantity(item, entry.Quantity);
+        if (entry.PreferredLocation != null && !item.Locations.Contains(entry.PreferredLocation))
+            entry.PreferredLocation = null;
 
         return true;
     }
 
     public bool Move(int from, int to)
+        => Functions.Move(entries, from, to);
+
+    public bool SetQuantity(int index, uint quantity)
     {
-        return Functions.Move(items, from, to);
+        if (index < 0 || index >= entries.Count)
+            return false;
+
+        var entry = entries[index];
+        quantity = NormalizeQuantity(entry.Item, quantity);
+        if (entry.Quantity == quantity)
+            return false;
+
+        entry.Quantity = quantity;
+        return true;
     }
 
-    public bool SetQuantity(IGatherable item, uint quantity)
+    public bool SetEnabled(int index, bool enabled)
     {
-        if (quantities.TryGetValue(item, out var old))
-        {
-            quantity = NormalizeQuantity(item, quantity);
+        if (index < 0 || index >= entries.Count)
+            return false;
 
-            if (old != quantity)
-            {
-                quantities[item] = quantity;
-                return true;
-            }
-        }
+        var entry = entries[index];
+        if (entry.Enabled == enabled)
+            return false;
 
-        return false;
-    }
-
-    public bool SetEnabled(IGatherable item, bool enabled)
-    {
-        if (enabledItems.TryGetValue(item, out var old))
-        {
-            if (old != enabled)
-            {
-                enabledItems[item] = enabled;
-                return true;
-            }
-        }
-
-        return false;
+        entry.Enabled = enabled;
+        return true;
     }
 
     private static uint NormalizeQuantity(IGatherable item, uint quantity)
@@ -135,36 +139,42 @@ public class AutoGatherList
         return quantity;
     }
 
-    public bool SetPreferredLocation(IGatherable item, ILocation? location)
+    public bool SetPreferredLocation(int index, ILocation? location)
     {
-        if (quantities.ContainsKey(item))
-        {
-            var old = preferredLocations.GetValueOrDefault(item);
-            if (old != location)
-            {
-                if (location == null)
-                    preferredLocations.Remove(item);
-                else
-                    preferredLocations[item] = location;
+        if (index < 0 || index >= entries.Count)
+            return false;
 
-                return true;
-            }
-        }
+        var entry = entries[index];
+        if (entry.PreferredLocation == location)
+            return false;
 
-        return false;
+        if (entries.Where((_, i) => i != index).Any(e => e.Item == entry.Item && e.PreferredLocation == location))
+            return false;
+
+        entry.PreferredLocation = location;
+        return true;
     }
 
     public bool HasItems()
-        => Enabled && Items.Count > 0;
+        => Enabled && entries.Count > 0;
 
     public struct Config(AutoGatherList list)
     {
-        public const byte CurrentVersion = 5;
+        public const byte CurrentVersion = 6;
 
-        public uint[]                 ItemIds            = list.Items.Select(i => i.ItemId).ToArray();
-        public Dictionary<uint, uint> Quantities         = list.Quantities.ToDictionary(v => v.Key.ItemId, v => v.Value);
-        public Dictionary<uint, uint> PrefferedLocations = list.PreferredLocations.ToDictionary(v => v.Key.ItemId, v => v.Value.Id);
-        public Dictionary<uint, bool> EnabledItems       = list.EnabledItems.ToDictionary(v => v.Key.ItemId, v => v.Value);
+        public struct EntryConfig(Entry entry)
+        {
+            public uint ItemId = entry.Item.ItemId;
+            public uint Quantity = entry.Quantity;
+            public uint? PreferredLocationId = entry.PreferredLocation?.Id;
+            public bool Enabled = entry.Enabled;
+        }
+
+        public EntryConfig[]          Entries            = list.entries.Select(e => new EntryConfig(e)).ToArray();
+        public uint[]                 ItemIds            = [];
+        public Dictionary<uint, uint> Quantities         = [];
+        public Dictionary<uint, uint> PrefferedLocations = [];
+        public Dictionary<uint, bool> EnabledItems       = [];
         public string                 Name               = list.Name;
         public string                 Description        = list.Description;
         public string                 FolderPath         = list.FolderPath;
@@ -186,12 +196,13 @@ public class AutoGatherList
             try
             {
                 var bytes = Functions.DecompressedBase64(data);
-                if (bytes.Length == 0 || (bytes[0] != CurrentVersion && bytes[0] != 4))
+                if (bytes.Length == 0 || (bytes[0] != CurrentVersion && bytes[0] != 5 && bytes[0] != 4))
                     return false;
 
                 var json = Encoding.UTF8.GetString(bytes.AsSpan()[1..]);
                 cfg = JsonConvert.DeserializeObject<Config>(json);
                 if (cfg.ItemIds == null
+                 || cfg.Entries == null
                  || cfg.Name == null
                  || cfg.Description == null
                  || cfg.Quantities == null
@@ -210,64 +221,98 @@ public class AutoGatherList
 
     public static bool FromConfig(Config cfg, out AutoGatherList list)
     {
-        //Migrate Individual Enabled
         if (cfg.EnabledItems == null || cfg.EnabledItems.Count == 0)
         {
             cfg.EnabledItems = new(cfg.ItemIds.Length);
             foreach (var item in cfg.ItemIds)
-            {
                 cfg.EnabledItems[item] = true;
-            }
         }
 
-        list = new AutoGatherList()
+        list = new AutoGatherList
         {
-            Name               = cfg.Name,
-            Description        = cfg.Description,
-            FolderPath         = cfg.FolderPath ?? string.Empty,
-            Order              = cfg.Order,
-            Enabled            = cfg.Enabled,
-            Fallback           = cfg.Fallback,
-            items              = new(cfg.ItemIds.Length),
-            quantities         = new(cfg.ItemIds.Length),
-            preferredLocations = new(cfg.PrefferedLocations.Count),
-            enabledItems       = new(cfg.EnabledItems.Count),
+            Name        = cfg.Name,
+            Description = cfg.Description,
+            FolderPath  = cfg.FolderPath ?? string.Empty,
+            Order       = cfg.Order,
+            Enabled     = cfg.Enabled,
+            Fallback    = cfg.Fallback,
         };
+
         var changes = false;
-        foreach (var itemId in cfg.ItemIds)
+
+        if (cfg.Entries.Length > 0)
         {
-            uint quantity;
-            IGatherable? item;
-
-            if (GatherBuddy.GameData.Gatherables.TryGetValue(itemId, out var gatherable))
-                item = gatherable;
-            else if (GatherBuddy.GameData.Fishes.TryGetValue(itemId, out var fish))
-                item = fish;
-            else
-                continue;
-
-            if (list.Add(item, quantity = cfg.Quantities.GetValueOrDefault(item.ItemId)))
+            foreach (var entryCfg in cfg.Entries)
             {
-                changes |= list.quantities[item] != quantity;
-                if (cfg.PrefferedLocations.TryGetValue(itemId, out var locId))
+                if (!TryResolveItem(entryCfg.ItemId, out var item))
+                    continue;
+
+                ILocation? location = null;
+                if (entryCfg.PreferredLocationId is { } locId)
                 {
-                    if (item.Locations.FirstOrDefault(n => n.Id == locId) is var loc and not null)
-                        list.SetPreferredLocation(item, loc);
-                    else
+                    location = item.Locations.FirstOrDefault(n => n.Id == locId);
+                    if (location == null)
                         changes = true;
                 }
 
-                if (cfg.EnabledItems.TryGetValue(itemId, out var enabled))
-                    list.SetEnabled(item, enabled);
+                list.entries.Add(new Entry
+                {
+                    Item = item,
+                    Quantity = NormalizeQuantity(item, entryCfg.Quantity),
+                    PreferredLocation = location,
+                    Enabled = entryCfg.Enabled,
+                });
             }
+
+            return changes;
+        }
+
+        foreach (var itemId in cfg.ItemIds)
+        {
+            if (!TryResolveItem(itemId, out var item))
+                continue;
+
+            var quantity = cfg.Quantities.GetValueOrDefault(item.ItemId);
+            if (!list.Add(item, quantity))
+                continue;
+
+            var entry = list.entries[^1];
+            changes |= entry.Quantity != quantity;
+            if (cfg.PrefferedLocations.TryGetValue(itemId, out var locId))
+            {
+                if (item.Locations.FirstOrDefault(n => n.Id == locId) is var loc and not null)
+                    entry.PreferredLocation = loc;
+                else
+                    changes = true;
+            }
+
+            if (cfg.EnabledItems.TryGetValue(itemId, out var enabled))
+                entry.Enabled = enabled;
         }
 
         return changes;
     }
 
+    private static bool TryResolveItem(uint itemId, [NotNullWhen(true)] out IGatherable? item)
+    {
+        if (GatherBuddy.GameData.Gatherables.TryGetValue(itemId, out var gatherable))
+        {
+            item = gatherable;
+            return true;
+        }
+
+        if (GatherBuddy.GameData.Fishes.TryGetValue(itemId, out var fish))
+        {
+            item = fish;
+            return true;
+        }
+
+        item = null;
+        return false;
+    }
+
     public AutoGatherList()
     { }
-
 
     public AutoGatherList(TimedGroup group)
     {

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.ManipPreset.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.ManipPreset.cs
@@ -118,7 +118,7 @@ public partial class AutoGatherListsManager
     {
         try
         {
-            var fishInList = list.Items.OfType<Fish>().Where(f => !f.IsSpearFish && list.EnabledItems.TryGetValue(f, out var enabled) && enabled).ToList();
+            var fishInList = list.Entries.Where(e => e.Enabled).Select(e => e.Item).OfType<Fish>().Where(f => !f.IsSpearFish).ToList();
             if (fishInList.Count == 0)
                 return true;
             
@@ -214,7 +214,7 @@ public partial class AutoGatherListsManager
     {
         try
         {
-            var gatherablesInList = list.Items.OfType<Gatherable>().Where(g => list.EnabledItems.TryGetValue(g, out var enabled) && enabled).ToList();
+            var gatherablesInList = list.Entries.Where(e => e.Enabled).Select(e => e.Item).OfType<Gatherable>().ToList();
             if (gatherablesInList.Count == 0)
                 return true;
             
@@ -372,16 +372,8 @@ public partial class AutoGatherListsManager
 
     public void AddItem(AutoGatherList list, IGatherable item)
     {
-        if (list.Add(item))
+        if (AddItemInternal(list, item, null))
         {
-            if (list.Enabled && !ValidateSingleFishBait(item))
-            {
-                list.SetEnabled(item, false);
-            }
-            if (list.Enabled && !ValidateSingleGatherablePerception(item))
-            {
-                list.SetEnabled(item, false);
-            }
             Save();
             if (list.Enabled)
                 SetActiveItems();
@@ -390,7 +382,7 @@ public partial class AutoGatherListsManager
 
     public void RemoveItem(AutoGatherList list, int idx)
     {
-        if (idx < 0 || idx >= list.Items.Count)
+        if (idx < 0 || idx >= list.Entries.Count)
             return;
 
         list.RemoveAt(idx);
@@ -401,7 +393,7 @@ public partial class AutoGatherListsManager
 
     public void ChangeItem(AutoGatherList list, IGatherable item, int idx)
     {
-        if (idx < 0 || idx >= list.Items.Count)
+        if (idx < 0 || idx >= list.Entries.Count)
             return;
 
         if (list.Replace(idx, item))
@@ -412,9 +404,9 @@ public partial class AutoGatherListsManager
         }
     }
 
-    public void ChangeQuantity(AutoGatherList list, IGatherable item, uint quantity)
+    public void ChangeQuantity(AutoGatherList list, int idx, uint quantity)
     {
-        if (list.SetQuantity(item, quantity))
+        if (list.SetQuantity(idx, quantity))
         {
             Save();
             if (list.Enabled)
@@ -422,8 +414,12 @@ public partial class AutoGatherListsManager
         }
     }
 
-    public void ChangeEnabled(AutoGatherList list, IGatherable item, bool enabled)
+    public void ChangeEnabled(AutoGatherList list, int idx, bool enabled)
     {
+        if (idx < 0 || idx >= list.Entries.Count)
+            return;
+
+        var item = list.Entries[idx].Item;
         if (enabled && list.Enabled && !ValidateSingleFishBait(item))
         {
             return;
@@ -434,7 +430,7 @@ public partial class AutoGatherListsManager
             return;
         }
         
-        if (list.SetEnabled(item, enabled))
+        if (list.SetEnabled(idx, enabled))
         {
             Save();
             if (list.Enabled)
@@ -454,16 +450,18 @@ public partial class AutoGatherListsManager
 
     public void MoveItem(AutoGatherList source, AutoGatherList destination, int idx)
     {
-        var item = source.Items[idx];
-        var quantity = source.Quantities[item];
-        if (destination.Add(item, quantity))
+        var entry = source.Entries[idx];
+        if (destination.Add(entry.Item, entry.Quantity, entry.PreferredLocation))
         {
-            destination.SetEnabled(item, source.EnabledItems[item]);
-            destination.SetPreferredLocation(item, source.PreferredLocations.GetValueOrDefault(item));
+            destination.SetEnabled(destination.Entries.Count - 1, entry.Enabled);
         }
         else
         {
-            destination.SetQuantity(item, destination.Quantities[item] + quantity);
+            var existingIdx = destination.Entries
+                .Select((e, i) => (Entry: e, Index: i))
+                .First(x => x.Entry.Item == entry.Item && x.Entry.PreferredLocation == entry.PreferredLocation)
+                .Index;
+            destination.SetQuantity(existingIdx, destination.Entries[existingIdx].Quantity + entry.Quantity);
         }
         source.RemoveAt(idx);
         Save();
@@ -471,13 +469,13 @@ public partial class AutoGatherListsManager
             SetActiveItems();
     }
 
-    public void ChangePreferredLocation(AutoGatherList list, IGatherable? item, ILocation? location)
+    public void ChangePreferredLocation(AutoGatherList list, int idx, ILocation? location)
     {
-        if (item == null)
-            return;
-        if (list.SetPreferredLocation(item, location))
+        if (list.SetPreferredLocation(idx, location))
         {
             Save();
+            if (list.Enabled)
+                SetActiveItems();
         }
     }
 
@@ -526,15 +524,22 @@ public partial class AutoGatherListsManager
         }
     }
 
-    public ILocation? GetPreferredLocation(IGatherable item)
+    private bool AddItemInternal(AutoGatherList list, IGatherable item, ILocation? location)
     {
-        foreach (var list in _fileSystem.Select(kvp => kvp.Key))
+        if (!list.Add(item, preferredLocation: location))
+            return false;
+
+        var idx = list.Entries.Count - 1;
+        if (list.Enabled && !ValidateSingleFishBait(item))
         {
-            if (list.Enabled && !list.Fallback && list.PreferredLocations.TryGetValue(item, out var loc))
-            {
-                return loc;
-            }
+            list.SetEnabled(idx, false);
         }
-        return null;
+
+        if (list.Enabled && !ValidateSingleGatherablePerception(item))
+        {
+            list.SetEnabled(idx, false);
+        }
+
+        return true;
     }
 }

--- a/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
+++ b/GatherBuddy/AutoGather/Lists/AutoGatherListsManager.cs
@@ -37,9 +37,9 @@ public partial class AutoGatherListsManager : IDisposable
     private const string FileName         = "auto_gather_lists.json";
     private const string FileNameFallback = "gather_window.json";
 
-    private readonly FileSystem<AutoGatherList>             _fileSystem;
-    private readonly List<(IGatherable Item, uint Quantity)> _activeItems   = [];
-    private readonly List<(IGatherable Item, uint Quantity)> _fallbackItems = [];
+    private readonly FileSystem<AutoGatherList> _fileSystem;
+    private readonly List<(IGatherable Item, uint Quantity, ILocation? PreferredLocation)> _activeItems   = [];
+    private readonly List<(IGatherable Item, uint Quantity, ILocation? PreferredLocation)> _fallbackItems = [];
     public static ManualOrderSortMode SortMode { get; } = new();
 
     public FileSystem<AutoGatherList> FileSystem
@@ -48,10 +48,10 @@ public partial class AutoGatherListsManager : IDisposable
     public IEnumerable<AutoGatherList> Lists
         => _fileSystem.Select(kvp => kvp.Key);
 
-    public ReadOnlyCollection<(IGatherable Item, uint Quantity)> ActiveItems
+    public ReadOnlyCollection<(IGatherable Item, uint Quantity, ILocation? PreferredLocation)> ActiveItems
         => _activeItems.AsReadOnly();
 
-    public ReadOnlyCollection<(IGatherable Item, uint Quantity)> FallbackItems
+    public ReadOnlyCollection<(IGatherable Item, uint Quantity, ILocation? PreferredLocation)> FallbackItems
         => _fallbackItems.AsReadOnly();
 
     public AutoGatherListsManager()
@@ -125,20 +125,20 @@ public partial class AutoGatherListsManager : IDisposable
             .OfType<FileSystem<AutoGatherList>.Leaf>()
             .Select(leaf => leaf.Value)
             .Where(l => l.Enabled)
-            .SelectMany(l => l.Items.Select(i => (Item: i, Quantity: l.Quantities[i], l.Fallback, ItemEnabled: l.EnabledItems[i])))
-            .Where(i => i.ItemEnabled)
-            .GroupBy(i => (i.Item, i.Fallback))
-            .Select(x => (x.Key.Item, Quantity: (uint)Math.Min(x.Sum(g => g.Quantity), uint.MaxValue), x.Key.Fallback));
+            .SelectMany(l => l.Entries.Select(e => (e.Item, e.Quantity, e.PreferredLocation, l.Fallback, e.Enabled)))
+            .Where(e => e.Enabled)
+            .GroupBy(e => (e.Item, e.PreferredLocation, e.Fallback))
+            .Select(x => (x.Key.Item, Quantity: (uint)Math.Min(x.Sum(g => g.Quantity), uint.MaxValue), x.Key.PreferredLocation, x.Key.Fallback));
 
-        foreach (var (item, quantity, fallback) in items)
+        foreach (var (item, quantity, preferredLocation, fallback) in items)
         {
             if (fallback)
             {
-                _fallbackItems.Add((item, quantity));
+                _fallbackItems.Add((item, quantity, preferredLocation));
             }
             else
             {
-                _activeItems.Add((item, quantity));
+                _activeItems.Add((item, quantity, preferredLocation));
             }
         }
 

--- a/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
+++ b/GatherBuddy/GatherHelper/GatherWindow.Ui.cs
@@ -168,6 +168,7 @@ public class GatherWindow : Window
             return;
 
         var hasPredatorIssue = HasPredatorTimerIssue(item);
+        var locationVisited = IsVisitedLocation(loc);
 
         if (ImGui.TableNextColumn())
         {
@@ -181,18 +182,14 @@ public class GatherWindow : Window
             var colorId = time == TimeInterval.Always    ? ColorId.GatherWindowText :
                 time.Start > GatherBuddy.Time.ServerTime ? ColorId.GatherWindowUpcoming : ColorId.GatherWindowAvailable;
 
-            if (quantity > 0 && inventoryCount >= quantity)
+            if (quantity > 0 && inventoryCount >= quantity || locationVisited)
                 colorId = ColorId.DisabledText;
             using var color                         = ImRaii.PushColor(ImGuiCol.Text, colorId.Value());
             var quantityText = quantity > 0 ? $" ({inventoryCount}/{quantity})" : "";
-            if (ImGui.Selectable($"{item.Name[GatherBuddy.Language]}{quantityText}", false))
+            var locationText = item.Locations.Count > 1 && quantity > 0 ? $" - {loc.Name}" : string.Empty;
+            if (ImGui.Selectable($"{item.Name[GatherBuddy.Language]}{locationText}{quantityText}##{item.ItemId}-{loc.Type}-{loc.Id}", false))
             {
-                if (_plugin.Executor.LastItem != item)
-                    _plugin.Executor.GatherItem(item);
-                else if (item is Gatherable)
-                    _plugin.Executor.GatherItemByName("next");
-                else
-                    _plugin.Executor.GatherFishByName("next");
+                _plugin.Executor.GatherLocation(loc);
             }
 
             var clicked = ImGui.IsItemClicked(ImGuiMouseButton.Right);
@@ -207,11 +204,12 @@ public class GatherWindow : Window
                         if (!list.Enabled)
                             continue;
 
-                        var idx = list.Items.IndexOf(item);
+                        var idx = list.Entries.ToList().FindIndex(entry => entry.Item == item
+                            && (entry.PreferredLocation == loc || entry.PreferredLocation == null));
                         if (idx < 0)
                             continue;
 
-                        _plugin.AutoGatherListsManager.ChangeEnabled(list, item, false);
+                        _plugin.AutoGatherListsManager.ChangeEnabled(list, idx, false);
                         break;
                     }
             }
@@ -222,7 +220,8 @@ public class GatherWindow : Window
                         if (!list.Enabled)
                             continue;
 
-                        var idx = list.Items.IndexOf(item);
+                        var idx = list.Entries.ToList().FindIndex(entry => entry.Item == item
+                            && (entry.PreferredLocation == loc || entry.PreferredLocation == null));
                         if (idx < 0)
                             continue;
 
@@ -252,6 +251,14 @@ public class GatherWindow : Window
         }
 
         DrawTime(loc, time, hasPredatorIssue);
+    }
+
+    private static bool IsVisitedLocation(ILocation loc)
+    {
+        if (loc is GatheringNode node && GatherBuddy.AutoGather.DebugVisitedTimedLocations.ContainsKey(node))
+            return true;
+
+        return loc.WorldPositions.Keys.Any(k => GatherBuddy.AutoGather.VisitedNodes.Contains(k));
     }
 
     private void DeleteItem()
@@ -298,19 +305,52 @@ public class GatherWindow : Window
     {
         _data.Clear();
 
-        var list = _plugin.AutoGatherListsManager.ActiveItems
-            .Select(x => (x.Item, x.Quantity))
-            .Concat(_plugin.GatherWindowManager.ActiveItems.Select(i => (Item: i, Quantity: 0u)))
-            .GroupBy(x => x.Item)
-            .Select(g => { var (loc, time) = GatherBuddy.UptimeManager.BestLocation(g.Key); return (g.Key, loc, time, (uint)g.Sum(x => x.Quantity)); });
+        IEnumerable<(IGatherable Item, ILocation Location, TimeInterval Uptime, uint Quantity)> list = _plugin.AutoGatherListsManager.ActiveItems
+            .SelectMany(ToGatherWindowRows)
+            .Concat(_plugin.GatherWindowManager.ActiveItems.Select(i =>
+            {
+                var (loc, time) = GatherBuddy.UptimeManager.BestLocation(i);
+                return (Item: i, Location: loc, Uptime: time, Quantity: 0u);
+            }))
+            .GroupBy(x => (x.Item, x.Location))
+            .Select(g => (g.Key.Item, g.Key.Location, g.First().Uptime, (uint)g.Sum(x => x.Quantity)));
 
         if (GatherBuddy.Config.SortGatherWindowByUptime)
-            list = list.OrderBy(i => i.time, Comparer<TimeInterval>.Create((x, y) => x.Compare(y)));
+            list = list.OrderBy(i => i.Uptime, Comparer<TimeInterval>.Create((x, y) => x.Compare(y)));
 
         _data.AddRange(list);
 
         return _data.Count == 0 || GatherBuddy.Config.ShowGatherWindowOnlyAvailable && _data.All(f => f.Uptime.Start > GatherBuddy.Time.ServerTime);
     }
+
+    private static IEnumerable<(IGatherable Item, ILocation Location, TimeInterval Uptime, uint Quantity)> ToGatherWindowRows(
+        (IGatherable Item, uint Quantity, ILocation? PreferredLocation) entry)
+    {
+        if (entry.PreferredLocation != null)
+        {
+            yield return (entry.Item, entry.PreferredLocation, GetLocationUptime(entry.Item, entry.PreferredLocation), entry.Quantity);
+            yield break;
+        }
+
+        if (GatherBuddy.Config.AutoGatherConfig.SplitGatherableForAllLocationsIfNoPreferenceSelected
+         && entry.Item.Locations.Count > 1)
+        {
+            foreach (var location in entry.Item.Locations)
+                yield return (entry.Item, location, GetLocationUptime(entry.Item, location), entry.Quantity);
+            yield break;
+        }
+
+        var (loc, time) = GatherBuddy.UptimeManager.BestLocation(entry.Item);
+        yield return (entry.Item, loc, time, entry.Quantity);
+    }
+
+    private static TimeInterval GetLocationUptime(IGatherable item, ILocation location)
+        => location switch
+        {
+            GatheringNode node => node.Times.NextUptime(GatherBuddy.Time.ServerTime),
+            FishingSpot spot when item is Fish fish => GatherBuddy.UptimeManager.NextUptime(fish, spot.Territory, GatherBuddy.Time.ServerTime),
+            _ => TimeInterval.Always,
+        };
 
     public override void PreOpenCheck()
     {

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -227,8 +227,14 @@ public partial class Interface
                                 continue;
                         }
 
-                        if(!list.Add(item, quantity))
-                            list.SetQuantity(item, quantity + list.Quantities[item]);
+                        if (!list.Add(item, quantity))
+                        {
+                            var existingIdx = list.Entries
+                                .Select((entry, i) => (entry, i))
+                                .First(x => x.entry.Item == item && x.entry.PreferredLocation == null)
+                                .i;
+                            list.SetQuantity(existingIdx, quantity + list.Entries[existingIdx].Quantity);
+                        }
                     }
 
                     _plugin.AutoGatherListsManager.Save();
@@ -292,24 +298,28 @@ public partial class Interface
         if (!box)
             return;
 
-        _autoGatherListsCache.SetExcludedGatherbales(list.Items.OfType<Gatherable>());
+        _autoGatherListsCache.SetExcludedGatherbales(list.Entries
+            .Where(e => e.PreferredLocation == null)
+            .Select(e => e.Item)
+            .OfType<Gatherable>());
         var gatherables = _autoGatherListsCache.FilteredGatherables;
         var selector    = _autoGatherListsCache.GatherableSelector;
         int changeIndex = -1, changeItemIndex = -1, deleteIndex = -1;
 
-        for (var i = 0; i < list.Items.Count; ++i)
+        for (var i = 0; i < list.Entries.Count; ++i)
         {
-            var       item  = list.Items[i];
-            using var id    = ImRaii.PushId((int)item.ItemId);
+            var entry = list.Entries[i];
+            var item = entry.Item;
+            using var id    = ImRaii.PushId(i);
             using var group = ImRaii.Group();
             if (ImGuiUtil.DrawDisabledButton(FontAwesomeIcon.Trash.ToIconString(), IconButtonSize, "Delete this item from the list", false,
                     true))
                 deleteIndex = i;
             ImGui.SameLine();
 
-            var enabled = list.EnabledItems[item];
+            var enabled = entry.Enabled;
             if (ImGui.Checkbox($"##{item.ItemId}", ref enabled))
-                _plugin.AutoGatherListsManager.ChangeEnabled(list, item, enabled);
+                _plugin.AutoGatherListsManager.ChangeEnabled(list, i, enabled);
 
             ImGui.SameLine();
             if (selector.Draw(item.Name[GatherBuddy.Language], out var newIdx))
@@ -324,13 +334,13 @@ public partial class Interface
             ImGui.SameLine(0f, ImGui.CalcTextSize($"0000 / ").X - ImGui.CalcTextSize($"{invTotal} / ").X);
             ImGui.Text($"{invTotal} / ");
             ImGui.SameLine(0, 3f);
-            var quantity = list.Quantities.TryGetValue(item, out var q) ? (int)q : 1;
+            var quantity = (int)entry.Quantity;
             ImGui.SetNextItemWidth(100f * Scale);
             if (ImGui.InputInt("##quantity", ref quantity, 1, 10))
-                _plugin.AutoGatherListsManager.ChangeQuantity(list, item, (uint)quantity);
+                _plugin.AutoGatherListsManager.ChangeQuantity(list, i, (uint)quantity);
             ImGui.SameLine();
-            if (DrawLocationInput(item, list.PreferredLocations.GetValueOrDefault(item), out var newLoc))
-                _plugin.AutoGatherListsManager.ChangePreferredLocation(list, item, newLoc);
+            if (DrawLocationInput(item, entry.PreferredLocation, out var newLoc))
+                _plugin.AutoGatherListsManager.ChangePreferredLocation(list, i, newLoc);
             group.Dispose();
 
             // Custom drag-drop for moving items within and between lists
@@ -367,10 +377,10 @@ public partial class Interface
             _plugin.AutoGatherListsManager.AddItem(list, gatherables[_autoGatherListsCache.NewGatherableIdx]);
 
         ImGui.SameLine();
-        var allEnabled = list.Items.All(i => list.EnabledItems[i]);
+        var allEnabled = list.Entries.All(e => e.Enabled);
         if (ImGui.Checkbox("##AllEnabled", ref allEnabled))
         {
-            foreach (var i in list.Items)
+            for (var i = 0; i < list.Entries.Count; ++i)
                 _plugin.AutoGatherListsManager.ChangeEnabled(list, i, allEnabled);
         }
         ImGuiUtil.HoverTooltip((allEnabled ? "Disable" : "Enable" ) + " all items in the list");
@@ -422,4 +432,3 @@ public partial class Interface
         });
     }
 }
-

--- a/GatherBuddy/Gui/Interface.ConfigTab.cs
+++ b/GatherBuddy/Gui/Interface.ConfigTab.cs
@@ -73,6 +73,12 @@ public partial class Interface
                 "This option has priority over going home when idle.",
                 GatherBuddy.Config.AutoGatherConfig.TeleportToNextNode, b => GatherBuddy.Config.AutoGatherConfig.TeleportToNextNode = b);
 
+        public static void DrawSplitGatherableForAllLocationsBox()
+            => DrawCheckbox("Split Gatherable for all its location if No Preference selected",
+                "When adding an item with multiple locations and no preferred location selected, create one auto-gather entry per location instead of a single shared entry.",
+                GatherBuddy.Config.AutoGatherConfig.SplitGatherableForAllLocationsIfNoPreferenceSelected,
+                b => GatherBuddy.Config.AutoGatherConfig.SplitGatherableForAllLocationsIfNoPreferenceSelected = b);
+
         public static void DrawGoHomeBox()
         {
             DrawCheckbox("Go home when done",                       "Uses the '/li auto' command to take you home when done gathering",
@@ -1608,6 +1614,7 @@ public partial class Interface
                 }
                 ConfigFunctions.DrawCheckRetainersBox();
                 ConfigFunctions.DrawTeleportToNextNodeBox();
+                ConfigFunctions.DrawSplitGatherableForAllLocationsBox();
                 ConfigFunctions.DrawGoHomeBox();
                 ConfigFunctions.DrawUseGivingLandOnCooldown();
                 ConfigFunctions.DrawUseSkillsForFallabckBox();

--- a/GatherBuddy/Gui/Interface.DebugTab.cs
+++ b/GatherBuddy/Gui/Interface.DebugTab.cs
@@ -194,7 +194,7 @@ public partial class Interface
                 foreach (var item in diademItems)
                 {
                     list.Add(item);
-                    list.SetQuantity(item, 1000);
+                    list.SetQuantity(list.Entries.Count - 1, 1000);
                 }
                 _plugin.AutoGatherListsManager.AddList(list);
             }


### PR DESCRIPTION
This pull request refactors how gatherable items and their associated data are stored and managed in the `AutoGatherList` class, moving from parallel collections to a unified `Entry` object model. It also adds a new configuration option to allow splitting gatherable items across all locations if no preference is set, and updates serialization/deserialization to support the new data structure. The changes improve code maintainability, extensibility, and enable more advanced item/location management.

### Data Model Refactoring

* Replaced parallel collections (`items`, `quantities`, `preferredLocations`, `enabledItems`) with a single `List<Entry>` in `AutoGatherList`, where each `Entry` holds an `IGatherable`, quantity, preferred location, and enabled status. All related methods and properties are updated to use the new model. [[1]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dR18-R42) [[2]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL37-R130) [[3]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL138-R177)
* Refactored methods for adding, removing, replacing, enabling, and setting quantities/locations to operate on entry indices instead of items, improving clarity and preventing duplicate entries with the same item and location. [[1]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL37-R130) [[2]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL138-R177)

### Serialization and Migration

* Updated the config version and serialization logic to store the new `Entry` structure, and added migration logic to load both old and new config formats, ensuring backward compatibility. [[1]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL138-R177) [[2]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL189-R205) [[3]](diffhunk://#diff-5de6177f17cc54436a9ad8a82c7249920a637b220fae211ba938102a5e9cb34dL213-L271)

### Location Preference and Splitting

* Added a new config option `SplitGatherableForAllLocationsIfNoPreferenceSelected` to `AutoGatherConfig`, and logic in the gather pipeline to optionally treat each location as a separate entry when no preferred location is set. [[1]](diffhunk://#diff-3ab4fd44d6d7d5541eb80f20a7ca549ae28e0cc3bb60ef96225f23adec05eff9R34) [[2]](diffhunk://#diff-0c737062a4fe369fa76639f479189d6567aeacee89e52a28862da9b046c7b0e9L201-R208) [[3]](diffhunk://#diff-0c737062a4fe369fa76639f479189d6567aeacee89e52a28862da9b046c7b0e9R307-R317)
* Updated grouping and selection logic in `UpdateItemsToGather` to support splitting gatherables by location when this option is enabled. [[1]](diffhunk://#diff-0c737062a4fe369fa76639f479189d6567aeacee89e52a28862da9b046c7b0e9L228-R227) [[2]](diffhunk://#diff-0c737062a4fe369fa76639f479189d6567aeacee89e52a28862da9b046c7b0e9R307-R317)

### Codebase Consistency

* Updated validation and manipulation methods throughout the codebase to use the new `Entry`-based API, ensuring all item modifications and queries are consistent with the new data model. [[1]](diffhunk://#diff-45b81dae3a8f2ca9bbc072ceddf6785b1022f7ced427c95343513ed3f64e1684L121-R121) [[2]](diffhunk://#diff-45b81dae3a8f2ca9bbc072ceddf6785b1022f7ced427c95343513ed3f64e1684L217-R217) [[3]](diffhunk://#diff-45b81dae3a8f2ca9bbc072ceddf6785b1022f7ced427c95343513ed3f64e1684L375-L384) [[4]](diffhunk://#diff-45b81dae3a8f2ca9bbc072ceddf6785b1022f7ced427c95343513ed3f64e1684L393-R385) [[5]](diffhunk://#diff-45b81dae3a8f2ca9bbc072ceddf6785b1022f7ced427c95343513ed3f64e1684L404-R396)

### Minor Fixes

* Updated method signatures and usages to reflect the new tuple structure for active items, ensuring correct destructuring and compatibility with the new model. [[1]](diffhunk://#diff-a28b38ff3ec881837d53ad8deeda2d7b69886a7a43673e0d54894079f940252bL2302-R2302) [[2]](diffhunk://#diff-0c737062a4fe369fa76639f479189d6567aeacee89e52a28862da9b046c7b0e9L144-R151)

These changes collectively modernize the gather list management, enable more flexible user options, and lay the groundwork for future enhancements.

---

This PR has been done using Codex and GPT 5.4
The main goal for me was to be able to have a list of all the Dark Matter inside the GBR Window so that I can teleport and follow correctly which one I did and did not do.

<img width="537" height="830" alt="image" src="https://github.com/user-attachments/assets/a3d12981-7766-4cc6-8ef2-204235d86c82" />
<img width="1011" height="917" alt="image" src="https://github.com/user-attachments/assets/88016616-d7f6-4bd9-9c31-a0866c39e3db" />
<img width="459" height="422" alt="image" src="https://github.com/user-attachments/assets/277d2961-6fd0-44c1-9683-a03c30b68e6f" />


