### PR TITLE
Small Tweaks

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.FishingCollectable.cs
+++ b/GatherBuddy/AutoGather/AutoGather.FishingCollectable.cs
@@ -34,7 +34,10 @@ namespace GatherBuddy.AutoGather
             var text = master.TextLegacy;
 
             if (!CollectablePatterns.Any(text.Contains))
+            {
+                GatherBuddy.Log.Debug($"[AutoCollectable] SelectYesno prompt did not match collectable patterns: {text}");
                 return false;
+            }
 
             GatherBuddy.Log.Debug($"[AutoCollectable] Detected collectable dialog with text: {text}");
 

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -1328,7 +1328,10 @@ namespace GatherBuddy.AutoGather
 
             if (IsFishing)
             {
-                GatherBuddy.Log.Debug($"[AutoGather] IsFishing block entered, timer will be checked. MaxFishingSpotMinutes={GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes}, Expiration={fishingSpotData.Expiration}");
+                if (GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes > 0)
+                {
+                    GatherBuddy.Log.Debug($"[AutoGather] IsFishing block entered, timer will be checked. MaxFishingSpotMinutes={GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes}, Expiration={fishingSpotData.Expiration}");
+                }
                 if (_fishWaryDetected)
                 {
                     _fishWaryDetected = false;

--- a/GatherBuddy/Automation/AddonMaster.cs
+++ b/GatherBuddy/Automation/AddonMaster.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Dalamud.Game.Text.SeStringHandling;
+using Dalamud.Memory;
 using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -56,7 +58,7 @@ public static unsafe class AddonMaster
         public SelectYesno(nint addon) : base(addon) { }
         public SelectYesno(void* addon) : base(addon) { }
 
-        public string TextLegacy => Addon->PromptText != null ? System.Text.RegularExpressions.Regex.Replace(Addon->PromptText->NodeText.ToString(), @"\s+", " ").Trim() : string.Empty;
+        public string TextLegacy => Addon->PromptText != null ? System.Text.RegularExpressions.Regex.Replace(MemoryHelper.ReadSeString(&Addon->PromptText->NodeText).TextValue, @"\s+", " ").Trim() : string.Empty;
 
         public void Yes()
         {
@@ -178,7 +180,8 @@ public static unsafe class AddonMaster
         public PurifyResult(nint addon) : base(addon) { }
         public PurifyResult(void* addon) : base(addon) { }
 
-        public string BannerText => Base->GetTextNodeById(2)->NodeText.ToString();
+        public SeString BannerSeString => MemoryHelper.ReadSeString(&Base->GetTextNodeById(2)->NodeText);
+        public string BannerText => BannerSeString.ToString();
         public AtkComponentButton* AutomaticButton => Addon->GetComponentButtonById(19);
         public AtkComponentButton* CloseButton => Addon->GetComponentButtonById(20);
 

--- a/GatherBuddy/Config/Configuration.cs
+++ b/GatherBuddy/Config/Configuration.cs
@@ -79,6 +79,7 @@ public partial class Configuration : IPluginConfiguration
     public string CraftingLists { get; set; } = string.Empty;
     public int MaxRecentCraftingListsInContextMenu { get; set; } = 10;
     public Vector2 TeamCraftImportWindowSize { get; set; } = new(520, 310);
+    public Vector2 VendorTeamCraftImportWindowSize { get; set; } = new(520, 310);
     public string RecipeBrowserSettings { get; set; } = string.Empty;
     public string UserMacros             { get; set; } = string.Empty;
     public bool   SkipMacroStepIfUnable { get; set; } = true;

--- a/GatherBuddy/Crafting/CraftingGameInterop.cs
+++ b/GatherBuddy/Crafting/CraftingGameInterop.cs
@@ -19,7 +19,13 @@ public static class CraftingGameInterop
     public enum CraftPreparationFailureReason
     {
         MissingIngredientsUnableToSelect,
+        MissingMaterialsUnableToQuickSynth,
     }
+
+    private static string GetItemName(uint itemId)
+        => Dalamud.GameData.GetExcelSheet<Item>()?.TryGetRow(itemId, out var item) == true
+            ? item.Name.ExtractText()
+            : $"Item {itemId}";
 
     public sealed record CraftPreparationFailure(
         uint RecipeId,
@@ -764,12 +770,16 @@ public static class CraftingGameInterop
                 GatherBuddy.Log.Warning("[Crafting] RecipeNote not visible for quick synthesis");
                 return;
             }
+            var qualityPolicy = _currentQualityPolicy;
+            var allowHQMaterials = qualityPolicy?.AllowHQMaterialsInQuickSynthesis ?? true;
+            if (!TryPrepareQuickSynthesisQuantity(quantity, allowHQMaterials, out var adjustedQuantity))
+                return;
 
-            _quickSynthTarget = quantity;
+            _quickSynthTarget = adjustedQuantity;
             _quickSynthCompleted = 0;
             _quickSynthWindowSeen = false;
             
-            GatherBuddy.Log.Debug($"[Crafting] Opening quick synthesis dialog");
+            GatherBuddy.Log.Debug($"[Crafting] Opening quick synthesis dialog for {_quickSynthTarget} item(s)");
             Callback.Fire(atkUnit, true, 9);
             
             var tm = GatherBuddy.AutoGather?.TaskManager;
@@ -777,12 +787,132 @@ public static class CraftingGameInterop
                 return;
                 
             tm.DelayNext(200);
-            tm.Enqueue(() => ConfirmQuickSynthesis(quantity), 3000, "ConfirmQuickSynthesis");
+            tm.Enqueue(() => ConfirmQuickSynthesis(_quickSynthTarget), 3000, "ConfirmQuickSynthesis");
         }
         catch (Exception ex)
         {
             GatherBuddy.Log.Error($"[Crafting] Failed to execute quick synthesis: {ex.Message}");
         }
+    }
+
+    private static unsafe bool TryPrepareQuickSynthesisQuantity(int requestedQuantity, bool allowHQMaterials, out int adjustedQuantity)
+    {
+        adjustedQuantity = Math.Clamp(requestedQuantity, 1, 99);
+
+        var (canEvaluate, maxCraftable, blockingItemId, neededPerCraft, availableNQ, availableHQ) =
+            EvaluateQuickSynthAvailability(allowHQMaterials);
+        var hasRecipeNoteCraftableCount = TryReadRecipeNoteCraftableCount(out var recipeNoteCraftableCount);
+        if (hasRecipeNoteCraftableCount)
+        {
+            GatherBuddy.Log.Debug($"[Crafting] Quick synthesis RecipeNote craftable count: {recipeNoteCraftableCount}");
+            if (!canEvaluate || recipeNoteCraftableCount < maxCraftable)
+                maxCraftable = recipeNoteCraftableCount;
+        }
+
+        if (!canEvaluate && !hasRecipeNoteCraftableCount)
+        {
+            GatherBuddy.Log.Debug("[Crafting] Quick synthesis material precheck unavailable, proceeding without clamp");
+            return true;
+        }
+
+        GatherBuddy.Log.Debug(
+            $"[Crafting] Quick synthesis material precheck: requested={requestedQuantity}, clamped={adjustedQuantity}, maxCraftable={maxCraftable}, allowHQMaterials={allowHQMaterials}");
+
+        if (maxCraftable <= 0)
+        {
+            if (blockingItemId != 0)
+            {
+                var itemName = GetItemName(blockingItemId);
+                var modeText = allowHQMaterials ? "using all available materials" : "using NQ-only materials";
+                SetPreparationFailure(
+                    CraftPreparationFailureReason.MissingMaterialsUnableToQuickSynth,
+                    blockingItemId,
+                    neededPerCraft,
+                    availableNQ,
+                    availableHQ,
+                    $"unable to quick synth '{itemName}' (item {blockingItemId}) {modeText}: needed per craft {neededPerCraft}, available NQ={availableNQ}, HQ={availableHQ}");
+                GatherBuddy.Log.Warning(
+                    $"[Crafting] Quick synthesis blocked by missing materials for '{itemName}' (item {blockingItemId})");
+            }
+            else
+            {
+                SetPreparationFailure(
+                    CraftPreparationFailureReason.MissingMaterialsUnableToQuickSynth,
+                    0,
+                    0,
+                    0,
+                    0,
+                    "RecipeNote reports 0 craftable items from current inventory for quick synthesis");
+                GatherBuddy.Log.Warning("[Crafting] Quick synthesis blocked because RecipeNote reports 0 craftable items from current inventory");
+            }
+            return false;
+        }
+
+        if (maxCraftable < adjustedQuantity)
+        {
+            var itemName = GetItemName(blockingItemId);
+            GatherBuddy.Log.Warning(
+                $"[Crafting] Quick synthesis batch reduced from {adjustedQuantity} to {maxCraftable} because '{itemName}' (item {blockingItemId}) is the limiting ingredient");
+            adjustedQuantity = maxCraftable;
+        }
+
+        return true;
+    }
+
+    private static unsafe (bool CanEvaluate, int MaxCraftable, uint BlockingItemId, int NeededPerCraft, int AvailableNQ, int AvailableHQ) EvaluateQuickSynthAvailability(bool allowHQMaterials)
+    {
+        var recipeNote = FFXIVClientStructs.FFXIV.Client.Game.UI.RecipeNote.Instance();
+        if (recipeNote == null || recipeNote->RecipeList == null || recipeNote->RecipeList->SelectedRecipe == null)
+            return (false, 0, 0, 0, 0, 0);
+
+        var ingredients = RecipeNoteExt.GetIngredientsSpan(recipeNote->RecipeList->SelectedRecipe);
+        var maxCraftable = int.MaxValue;
+        uint blockingItemId = 0;
+        var blockingNeeded = 0;
+        var blockingAvailableNQ = 0;
+        var blockingAvailableHQ = 0;
+
+        for (var i = 0; i < ingredients.Length; i++)
+        {
+            var ingredient = ingredients[i];
+            if (ingredient.ItemId == 0)
+                break;
+
+            if (ingredient.NumTotal == 0)
+                continue;
+
+            var availableNQ = ingredient.NumAvailableNQ;
+            var availableHQ = ingredient.NumAvailableHQ;
+            var availableTotal = allowHQMaterials ? availableNQ + availableHQ : availableNQ;
+            var craftableByIngredient = availableTotal / ingredient.NumTotal;
+
+            GatherBuddy.Log.Debug(
+                $"[Crafting] Quick synthesis ingredient check: item={ingredient.ItemId}, needed={ingredient.NumTotal}, availableNQ={availableNQ}, availableHQ={availableHQ}, allowHQMaterials={allowHQMaterials}, craftable={craftableByIngredient}");
+
+            if (craftableByIngredient >= maxCraftable)
+                continue;
+
+            maxCraftable = craftableByIngredient;
+            blockingItemId = ingredient.ItemId;
+            blockingNeeded = ingredient.NumTotal;
+            blockingAvailableNQ = availableNQ;
+            blockingAvailableHQ = availableHQ;
+        }
+
+        if (maxCraftable == int.MaxValue)
+            return (false, 0, 0, 0, 0, 0);
+
+        return (true, maxCraftable, blockingItemId, blockingNeeded, blockingAvailableNQ, blockingAvailableHQ);
+    }
+
+    private static unsafe bool TryReadRecipeNoteCraftableCount(out int craftableCount)
+    {
+        craftableCount = 0;
+        var addon = (AddonRecipeNote*)Dalamud.GameGui.GetAddonByName("RecipeNote").Address;
+        if (addon == null || !addon->AtkUnitBase.IsVisible || addon->SelectedRecipeQuantityCraftableFromMaterialsInInventory == null)
+            return false;
+
+        return int.TryParse(addon->SelectedRecipeQuantityCraftableFromMaterialsInInventory->NodeText.ToString(), out craftableCount);
     }
     
     private static unsafe bool ConfirmQuickSynthesis(int quantity)
@@ -982,23 +1112,42 @@ public static class CraftingGameInterop
     }
 
     private static void SetMissingIngredientFailure(uint itemId, int needed, int availableNQ, int availableHQ, string? detailsOverride = null)
-    {
-        if (!_currentRecipeId.HasValue)
-            return;
-
-        var itemName = Dalamud.GameData.GetExcelSheet<Item>()?.TryGetRow(itemId, out var item) == true
-            ? item.Name.ExtractText()
-            : $"Item {itemId}";
-        var details = detailsOverride ?? $"unable to select '{itemName}' (item {itemId}) in RecipeNote: needed {needed}, available NQ={availableNQ}, HQ={availableHQ}";
-        _lastPreparationFailure = new CraftPreparationFailure(
-            _currentRecipeId.Value,
+        => SetPreparationFailure(
             CraftPreparationFailureReason.MissingIngredientsUnableToSelect,
             itemId,
             needed,
             availableNQ,
             availableHQ,
+            detailsOverride);
+
+    private static void SetPreparationFailure(
+        CraftPreparationFailureReason reason,
+        uint itemId,
+        int needed,
+        int availableNQ,
+        int availableHQ,
+        string? detailsOverride = null)
+    {
+        if (!_currentRecipeId.HasValue)
+            return;
+
+        var itemName = GetItemName(itemId);
+        var details = detailsOverride ?? reason switch
+        {
+            CraftPreparationFailureReason.MissingMaterialsUnableToQuickSynth =>
+                $"unable to quick synth '{itemName}' (item {itemId}): needed {needed}, available NQ={availableNQ}, HQ={availableHQ}",
+            _ =>
+                $"unable to select '{itemName}' (item {itemId}) in RecipeNote: needed {needed}, available NQ={availableNQ}, HQ={availableHQ}",
+        };
+        _lastPreparationFailure = new CraftPreparationFailure(
+            _currentRecipeId.Value,
+            reason,
+            itemId,
+            needed,
+            availableNQ,
+            availableHQ,
             details);
-        GatherBuddy.Log.Warning($"[Crafting] Recipe {_currentRecipeId.Value} ingredient assignment failed due to missing ingredients: {details}");
+        GatherBuddy.Log.Warning($"[Crafting] Recipe {_currentRecipeId.Value} preparation failed ({reason}) due to missing materials: {details}");
     }
     private static CraftState TransitionFromPreparingCraft()
     {

--- a/GatherBuddy/Crafting/CraftingListManager.cs
+++ b/GatherBuddy/Crafting/CraftingListManager.cs
@@ -399,6 +399,56 @@ public class CraftingListManager
         return Convert.ToBase64String(Encoding.UTF8.GetBytes(json));
     }
 
+    public (string? Url, string? Error) ExportListToTeamCraft(int id)
+    {
+        var list = GetListByID(id);
+        if (list == null)
+            return (null, "The selected list no longer exists.");
+        if (list.Recipes.Count == 0)
+            return (null, "The selected list contains no recipes.");
+
+        const string baseUrl = "https://ffxivteamcraft.com/import/";
+        var orderedItemIds = new List<uint>();
+        var exportedItemQuantities = new Dictionary<uint, long>();
+
+        foreach (var item in list.Recipes)
+        {
+            if (item.Quantity <= 0)
+            {
+                GatherBuddy.Log.Debug($"[CraftingListManager] Skipping TeamCraft export entry for recipe {item.RecipeId} in '{list.Name}' because its quantity is {item.Quantity}.");
+                continue;
+            }
+
+            var recipe = RecipeManager.GetRecipe(item.RecipeId);
+            if (recipe == null)
+            {
+                GatherBuddy.Log.Debug($"[CraftingListManager] Skipping TeamCraft export entry for recipe {item.RecipeId} in '{list.Name}' because the recipe could not be resolved.");
+                continue;
+            }
+
+            var resultItemId = recipe.Value.ItemResult.RowId;
+            if (resultItemId == 0 || recipe.Value.AmountResult == 0)
+            {
+                GatherBuddy.Log.Debug($"[CraftingListManager] Skipping TeamCraft export entry for recipe {item.RecipeId} in '{list.Name}' because the result item or amount is invalid.");
+                continue;
+            }
+
+            var exportedQuantity = (long)item.Quantity * recipe.Value.AmountResult;
+            if (!exportedItemQuantities.TryAdd(resultItemId, exportedQuantity))
+                exportedItemQuantities[resultItemId] += exportedQuantity;
+            else
+                orderedItemIds.Add(resultItemId);
+        }
+
+        if (orderedItemIds.Count == 0)
+            return (null, "The selected list has no TeamCraft-exportable recipes.");
+
+        var payload = string.Join(";", orderedItemIds.Select(itemId => $"{itemId},null,{exportedItemQuantities[itemId]}"));
+        var base64 = Convert.ToBase64String(Encoding.UTF8.GetBytes(payload));
+        GatherBuddy.Log.Information($"[CraftingListManager] Exported list '{list.Name}' to TeamCraft with {orderedItemIds.Count} item(s)");
+        return ($"{baseUrl}{base64}", null);
+    }
+
     public (CraftingListDefinition? List, string? Error) ImportList(string base64)
     {
         try

--- a/GatherBuddy/Crafting/CraftingQueueProcessor.cs
+++ b/GatherBuddy/Crafting/CraftingQueueProcessor.cs
@@ -818,17 +818,21 @@ public class CraftingQueueProcessor
         var recipe = RecipeManager.GetRecipe(failure.RecipeId);
         var itemName = recipe != null ? recipe.Value.ItemResult.Value.Name.ExtractText() : $"Recipe {failure.RecipeId}";
         var priorFailures = _missingIngredientFailures.GetValueOrDefault(failure.RecipeId);
+        var failureContext = failure.Reason switch
+        {
+            CraftingGameInterop.CraftPreparationFailureReason.MissingMaterialsUnableToQuickSynth => "quick synthesis material pre-check",
+            _ => "RecipeNote ingredient assignment",
+        };
 
         if (priorFailures == 0)
         {
             _missingIngredientFailures[failure.RecipeId] = 1;
-            GatherBuddy.Log.Warning($"[CraftingQueueProcessor] Missing ingredients caused RecipeNote assignment failure for '{itemName}' (recipe {failure.RecipeId}): {failure.Details}. Retrying once before skipping remaining instances.");
+            GatherBuddy.Log.Warning($"[CraftingQueueProcessor] Missing materials caused {failureContext} failure for '{itemName}' (recipe {failure.RecipeId}): {failure.Details}. Retrying once before skipping remaining instances.");
             _currentState = QueueState.WaitingForJobSwitch;
             StateChanged?.Invoke(_currentState);
             return true;
         }
-
-        GatherBuddy.Log.Warning($"[CraftingQueueProcessor] Missing ingredients caused RecipeNote assignment to fail again for '{itemName}' (recipe {failure.RecipeId}): {failure.Details}. Skipping this and remaining instances of the recipe.");
+        GatherBuddy.Log.Warning($"[CraftingQueueProcessor] Missing materials caused {failureContext} to fail again for '{itemName}' (recipe {failure.RecipeId}): {failure.Details}. Skipping this and remaining instances of the recipe.");
         SkipRemainingRecipeInstances(failure.RecipeId);
         return true;
     }
@@ -844,7 +848,7 @@ public class CraftingQueueProcessor
 
             queueItem.Options.Skipping = true;
             skippedCount++;
-            GatherBuddy.Log.Debug($"[CraftingQueueProcessor] Marked queue index {i} for recipe {recipeId} as skipped after repeated missing-ingredient assignment failure");
+            GatherBuddy.Log.Debug($"[CraftingQueueProcessor] Marked queue index {i} for recipe {recipeId} as skipped after repeated missing-material preparation failure");
         }
 
         _missingIngredientFailures.Remove(recipeId);

--- a/GatherBuddy/Gui/CraftingListEditor.cs
+++ b/GatherBuddy/Gui/CraftingListEditor.cs
@@ -886,6 +886,37 @@ public class CraftingListEditor
                 ImGui.EndChild();
             }
         }
+
+        ImGui.Spacing();
+        var buttonWidth = (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X) / 2f;
+        if (ImGui.Button("Export List##exportList", new Vector2(buttonWidth, 0)))
+        {
+            var exported = GatherBuddy.CraftingListManager.ExportList(_list.ID);
+            if (exported != null)
+            {
+                ImGui.SetClipboardText(exported);
+                GatherBuddy.Log.Information($"[CraftingListEditor] Exported list '{_list.Name}' to clipboard");
+            }
+        }
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Copy GatherBuddy's list export string to the clipboard.");
+
+        ImGui.SameLine();
+        if (ImGui.Button("TeamCraft Export##teamCraftExport", new Vector2(-1, 0)))
+        {
+            var (exported, error) = GatherBuddy.CraftingListManager.ExportListToTeamCraft(_list.ID);
+            if (exported != null)
+            {
+                ImGui.SetClipboardText(exported);
+                GatherBuddy.Log.Information($"[CraftingListEditor] Exported list '{_list.Name}' to TeamCraft and copied the link to the clipboard");
+            }
+            else if (!string.IsNullOrEmpty(error))
+            {
+                GatherBuddy.Log.Warning($"[CraftingListEditor] Failed to export '{_list.Name}' to TeamCraft: {error}");
+            }
+        }
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("Copy a TeamCraft import link built from this list's Recipe List entries.");
     }
 
     private void DrawListConsumablesSection()

--- a/GatherBuddy/Gui/CraftingMaterialsWindow.cs
+++ b/GatherBuddy/Gui/CraftingMaterialsWindow.cs
@@ -29,7 +29,6 @@ public class CraftingMaterialsWindow : Window
     private static readonly Vector4 AccentShop   = new(0.80f, 0.55f, 1.00f, 1f);
     private static readonly Vector4 AccentVendor = new(1.00f, 0.85f, 0.20f, 1f);
     private static readonly Vector4 AccentCraft  = new(0.35f, 0.90f, 0.90f, 1f);
-    private static readonly Vector4 PanelBg      = new(0.08f, 0.08f, 0.10f, 1.00f);
     private enum RetainerColumnMode
     {
         None,
@@ -73,6 +72,8 @@ public class CraftingMaterialsWindow : Window
             ImGui.TextColored(new Vector4(0.7f, 0.7f, 0.7f, 1), "No list open.");
             return;
         }
+
+        using var theme = VulcanUiStyle.PushTheme();
 
         if (!_editor.HasCachedDisplayMaterials && !_editor.IsGeneratingMaterials)
             _editor.TriggerMaterialsRegeneration();
@@ -234,7 +235,7 @@ public class CraftingMaterialsWindow : Window
             .ThenBy(e => e.Name)
             .ToList();
 
-        using (ImRaii.PushColor(ImGuiCol.ChildBg, PanelBg))
+        using (VulcanUiStyle.PushPanel())
         {
             ImGui.BeginChild(id, new Vector2(width, height), true);
             var colCount = retainerColumnMode switch

--- a/GatherBuddy/Gui/Interface.Header.cs
+++ b/GatherBuddy/Gui/Interface.Header.cs
@@ -114,6 +114,27 @@ public partial class Interface
         ImGui.SameLine();
         ConfigFunctions.DrawAlarmToggle();
         ImGui.SameLine();
+        var vulcanButtonWidth = Math.Max(95f * Scale, ImGui.CalcTextSize("Vulcan").X + FramePadding.X * 5f);
+        {
+            using var buttonAlign = ImRaii.PushStyle(ImGuiStyleVar.ButtonTextAlign, new Vector2(0.5f, 0.5f));
+            using var buttonColor = ImRaii.PushColor(ImGuiCol.Button, new Vector4(0.30f, 0.25f, 0.46f, 1f));
+            using var buttonHoveredColor = ImRaii.PushColor(ImGuiCol.ButtonHovered, new Vector4(0.36f, 0.30f, 0.55f, 1f));
+            using var buttonActiveColor = ImRaii.PushColor(ImGuiCol.ButtonActive, new Vector4(0.24f, 0.20f, 0.38f, 1f));
+            if (ImGui.Button("Vulcan", new Vector2(vulcanButtonWidth, 0f)))
+            {
+                if (GatherBuddy.VulcanWindow == null)
+                {
+                    GatherBuddy.Log.Debug("[Interface] Vulcan header button clicked, but the Vulcan window was unavailable.");
+                }
+                else
+                {
+                    GatherBuddy.Log.Debug("[Interface] Restoring Vulcan from the main header button.");
+                    GatherBuddy.VulcanWindow.RestoreWindow();
+                }
+            }
+        }
+        ImGuiUtil.HoverTooltip("Open the Vulcan crafting window.");
+        ImGui.SameLine();
         _headerCache.AlarmButtonSize = (ImGui.GetContentRegionAvail().X - ItemSpacing.X) / 2 * Vector2.UnitX;
         DrawLastItemAlarm();
         ImGui.SameLine();

--- a/GatherBuddy/Gui/VendorBuyListWindow.TeamCraftImport.cs
+++ b/GatherBuddy/Gui/VendorBuyListWindow.TeamCraftImport.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+using Dalamud.Interface.Colors;
+using ElliLib.Raii;
+using GatherBuddy.Vulcan.Vendors;
+using ImRaii = ElliLib.Raii.ImRaii;
+
+namespace GatherBuddy.Gui;
+
+public sealed partial class VendorBuyListWindow
+{
+    private static readonly Vector2 DefaultTeamCraftImportWindowSize = new(520, 310);
+    private const string TeamCraftImportWindowId = "Vendor TeamCraft Import###VendorTeamCraftImport";
+
+    private bool _showTeamCraftImport;
+
+    private string _teamCraftImportListName = string.Empty;
+    private string _teamCraftImportText = string.Empty;
+    private string? _teamCraftImportError;
+    private bool _teamCraftImportIntoExistingList;
+    private Guid? _teamCraftImportTargetListId;
+    private bool _focusTeamCraftImportListName;
+    private Vector2 _teamCraftImportWindowSize;
+    private bool _teamCraftImportWindowSizeDirty;
+
+    private void OpenTeamCraftImportWindow(VendorBuyListManager manager)
+    {
+        _teamCraftImportListName = "Imported from TeamCraft";
+        _teamCraftImportText = string.Empty;
+        _teamCraftImportError = null;
+        _teamCraftImportIntoExistingList = false;
+        _teamCraftImportTargetListId = GetDefaultTeamCraftImportTargetListId(manager);
+        _focusTeamCraftImportListName = true;
+        _showTeamCraftImport = true;
+    }
+
+    private void ResetTeamCraftImportWindowState()
+    {
+        _teamCraftImportListName = string.Empty;
+        _teamCraftImportText = string.Empty;
+        _teamCraftImportError = null;
+        _teamCraftImportIntoExistingList = false;
+        _teamCraftImportTargetListId = null;
+        _focusTeamCraftImportListName = false;
+        _showTeamCraftImport = false;
+    }
+
+    private void DrawTeamCraftImportWindow(VendorBuyListManager manager)
+    {
+        if (!_showTeamCraftImport)
+            return;
+
+        ImGui.SetNextWindowSize(_teamCraftImportWindowSize, ImGuiCond.Appearing);
+        var isOpen = _showTeamCraftImport;
+        var drawWindow = ImGui.Begin(TeamCraftImportWindowId, ref isOpen, ImGuiWindowFlags.NoCollapse);
+        _showTeamCraftImport = isOpen;
+
+        var currentWindowSize = NormalizeTeamCraftImportWindowSize(ImGui.GetWindowSize());
+        if (HasTeamCraftImportWindowSizeChanged(currentWindowSize, _teamCraftImportWindowSize))
+        {
+            _teamCraftImportWindowSize = currentWindowSize;
+            _teamCraftImportWindowSizeDirty = true;
+        }
+
+        if (_teamCraftImportWindowSizeDirty && !ImGui.IsMouseDown(ImGuiMouseButton.Left))
+            SaveTeamCraftImportWindowSize();
+
+        if (!drawWindow)
+        {
+            if (!_showTeamCraftImport)
+                SaveTeamCraftImportWindowSize(true);
+            ImGui.End();
+            return;
+        }
+
+        ImGui.TextColored(ImGuiColors.DalamudGrey3, "Paste the TeamCraft 'Vendors' text section below.");
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
+        NormalizeTeamCraftImportTargetListId(manager);
+        var footerHeight = ImGui.GetFrameHeightWithSpacing() + ImGui.GetStyle().ItemSpacing.Y * 3f + 2f;
+        ImGui.BeginChild("##vendorTeamCraftImportContent", new Vector2(0, -footerHeight), false);
+        if (manager.Lists.Count > 0)
+        {
+            ImGui.Text("Destination");
+            if (ImGui.RadioButton("New List##vendorTeamCraftNewList", !_teamCraftImportIntoExistingList))
+            {
+                _teamCraftImportIntoExistingList = false;
+                _teamCraftImportError = null;
+                _focusTeamCraftImportListName = true;
+            }
+            ImGui.SameLine();
+            if (ImGui.RadioButton("Existing List##vendorTeamCraftExistingList", _teamCraftImportIntoExistingList))
+            {
+                _teamCraftImportIntoExistingList = true;
+                _teamCraftImportError = null;
+            }
+            ImGui.Spacing();
+        }
+
+        if (_teamCraftImportIntoExistingList)
+        {
+            var selectedList = GetTeamCraftImportTargetList(manager);
+            ImGui.Text("Target List");
+            ImGui.SetNextItemWidth(-1);
+            if (ImGui.BeginCombo("##vendorTeamCraftImportTargetList", selectedList?.Name ?? "Select a list"))
+            {
+                foreach (var list in manager.Lists)
+                {
+                    var isSelected = selectedList != null && list.Id == selectedList.Id;
+                    if (ImGui.Selectable(list.Name, isSelected))
+                    {
+                        _teamCraftImportTargetListId = list.Id;
+                        _teamCraftImportError = null;
+                    }
+                    if (isSelected)
+                        ImGui.SetItemDefaultFocus();
+                }
+                ImGui.EndCombo();
+            }
+        }
+        else
+        {
+            ImGui.Text("List Name");
+            if (_focusTeamCraftImportListName)
+            {
+                ImGui.SetKeyboardFocusHere();
+                _focusTeamCraftImportListName = false;
+            }
+
+            ImGui.SetNextItemWidth(-1);
+            ImGui.InputText("##vendorTeamCraftImportListName", ref _teamCraftImportListName, 128);
+        }
+
+        ImGui.Spacing();
+        ImGui.Text("Vendor Items");
+        ImGui.SetNextItemWidth(-1);
+        var errorHeight = _teamCraftImportError != null
+            ? ImGui.GetTextLineHeightWithSpacing() + ImGui.GetStyle().ItemSpacing.Y
+            : 0f;
+        var vendorItemsHeight = Math.Max(150f, ImGui.GetContentRegionAvail().Y - errorHeight);
+        ImGui.InputTextMultiline("##vendorTeamCraftImportText", ref _teamCraftImportText, 500000, new Vector2(-1, vendorItemsHeight));
+
+        if (_teamCraftImportError != null)
+        {
+            ImGui.Spacing();
+            ImGui.TextColored(ImGuiColors.DalamudRed, _teamCraftImportError);
+        }
+        ImGui.EndChild();
+
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
+        var selectedTargetList = _teamCraftImportIntoExistingList
+            ? GetTeamCraftImportTargetList(manager)
+            : null;
+        using (ImRaii.Disabled(string.IsNullOrWhiteSpace(_teamCraftImportText)
+            || (_teamCraftImportIntoExistingList && selectedTargetList == null)))
+        {
+            if (ImGui.Button("Import", new Vector2(120f, 0)))
+            {
+                var result = manager.ImportTeamCraftList(
+                    _teamCraftImportText,
+                    _teamCraftImportIntoExistingList ? _teamCraftImportTargetListId : null,
+                    _teamCraftImportListName);
+                if (result.List != null)
+                {
+                    ResetTeamCraftImportWindowState();
+                }
+                else
+                {
+                    _teamCraftImportError = result.Error;
+                }
+            }
+        }
+
+        ImGui.SameLine();
+        if (ImGui.Button("Cancel", new Vector2(100f, 0)))
+        {
+            ResetTeamCraftImportWindowState();
+        }
+
+        if (!_showTeamCraftImport)
+            SaveTeamCraftImportWindowSize(true);
+
+        ImGui.End();
+    }
+
+    private static Guid? GetDefaultTeamCraftImportTargetListId(VendorBuyListManager manager)
+    {
+        var activeListId = manager.ActiveList?.Id;
+        if (activeListId.HasValue)
+            return activeListId.Value;
+
+        return manager.Lists.Count > 0
+            ? manager.Lists[0].Id
+            : null;
+    }
+
+    private void NormalizeTeamCraftImportTargetListId(VendorBuyListManager manager)
+    {
+        if (manager.Lists.Count == 0)
+        {
+            _teamCraftImportIntoExistingList = false;
+            _teamCraftImportTargetListId = null;
+            return;
+        }
+
+        if (_teamCraftImportTargetListId.HasValue)
+        {
+            foreach (var list in manager.Lists)
+            {
+                if (list.Id == _teamCraftImportTargetListId.Value)
+                    return;
+            }
+        }
+
+        _teamCraftImportTargetListId = GetDefaultTeamCraftImportTargetListId(manager);
+    }
+
+    private VendorBuyListDefinition? GetTeamCraftImportTargetList(VendorBuyListManager manager)
+    {
+        NormalizeTeamCraftImportTargetListId(manager);
+        if (!_teamCraftImportTargetListId.HasValue)
+            return null;
+
+        foreach (var list in manager.Lists)
+        {
+            if (list.Id == _teamCraftImportTargetListId.Value)
+                return list;
+        }
+
+        return null;
+    }
+
+    private static Vector2 NormalizeTeamCraftImportWindowSize(Vector2 size)
+        => size.X > 0 && size.Y > 0 ? size : DefaultTeamCraftImportWindowSize;
+
+    private static bool HasTeamCraftImportWindowSizeChanged(Vector2 lhs, Vector2 rhs)
+        => MathF.Abs(lhs.X - rhs.X) > 0.5f || MathF.Abs(lhs.Y - rhs.Y) > 0.5f;
+
+    private void SaveTeamCraftImportWindowSize(bool force = false)
+    {
+        if (!force && !_teamCraftImportWindowSizeDirty)
+            return;
+
+        var normalizedSize = NormalizeTeamCraftImportWindowSize(_teamCraftImportWindowSize);
+        if (HasTeamCraftImportWindowSizeChanged(GatherBuddy.Config.VendorTeamCraftImportWindowSize, normalizedSize))
+        {
+            GatherBuddy.Config.VendorTeamCraftImportWindowSize = normalizedSize;
+            GatherBuddy.Config.Save();
+            GatherBuddy.Log.Debug($"[VendorBuyListWindow] Saved vendor TeamCraft import window size: {normalizedSize.X}x{normalizedSize.Y}");
+        }
+
+        _teamCraftImportWindowSizeDirty = false;
+    }
+}

--- a/GatherBuddy/Gui/VendorBuyListWindow.cs
+++ b/GatherBuddy/Gui/VendorBuyListWindow.cs
@@ -14,7 +14,7 @@ using ImRaii = ElliLib.Raii.ImRaii;
 
 namespace GatherBuddy.Gui;
 
-public sealed class VendorBuyListWindow : Window
+public sealed partial class VendorBuyListWindow : Window
 {
     private sealed record VendorListNpcOption(VendorNpc Npc, VendorNpcLocation? Location, string ZoneName);
     private readonly record struct VendorCurrencyRequirement(
@@ -25,7 +25,6 @@ public sealed class VendorBuyListWindow : Window
         ulong RequiredAmount);
     public const string WindowId = "Vendor Buy List###VendorBuyListWindow";
     private const string ListNamePopupId = "Vendor Buy List Name###VendorBuyListNamePopup";
-    private static readonly Vector4 PanelBackgroundColor = new(0.08f, 0.08f, 0.10f, 1f);
     private readonly Dictionary<uint, ushort> _currencyIconIds = new();
     private readonly Dictionary<uint, string> _currencyNames = new();
 
@@ -47,6 +46,7 @@ public sealed class VendorBuyListWindow : Window
             MinimumSize = new Vector2(640, 320),
             MaximumSize = new Vector2(float.MaxValue, float.MaxValue),
         };
+        _teamCraftImportWindowSize = NormalizeTeamCraftImportWindowSize(GatherBuddy.Config.VendorTeamCraftImportWindowSize);
         ShowCloseButton = true;
         RespectCloseHotkey = true;
         IsOpen = false;
@@ -119,6 +119,8 @@ public sealed class VendorBuyListWindow : Window
         if (manager == null)
             return;
 
+        using var theme = VulcanUiStyle.PushTheme();
+
         var isFocused = ImGui.IsWindowFocused(ImGuiFocusedFlags.RootAndChildWindows);
         if (isFocused)
         {
@@ -140,7 +142,7 @@ public sealed class VendorBuyListWindow : Window
         var avail = ImGui.GetContentRegionAvail();
         var leftWidth = Math.Clamp(avail.X * 0.22f, 190f, 220f);
 
-        using (ImRaii.PushColor(ImGuiCol.ChildBg, PanelBackgroundColor))
+        using (VulcanUiStyle.PushPanel())
         {
             ImGui.BeginChild("##vendorBuyListLeftPanel", new Vector2(leftWidth, avail.Y), true);
             DrawListSidebar(manager, activeList);
@@ -149,7 +151,7 @@ public sealed class VendorBuyListWindow : Window
 
         ImGui.SameLine();
 
-        using (ImRaii.PushColor(ImGuiCol.ChildBg, PanelBackgroundColor))
+        using (VulcanUiStyle.PushPanel())
         {
             ImGui.BeginChild("##vendorBuyListRightPanel", new Vector2(0, avail.Y), true);
             DrawActiveListPanel(manager, activeList);
@@ -157,6 +159,7 @@ public sealed class VendorBuyListWindow : Window
         }
 
         DrawListNamePopup(manager);
+        DrawTeamCraftImportWindow(manager);
     }
 
     private static void DrawHeader()
@@ -182,6 +185,8 @@ public sealed class VendorBuyListWindow : Window
                 var list = manager.CreateList("Vendor List");
                 OpenListNamePopup(list.Id, list.Name);
             }
+            if (ImGui.Button("TeamCraft Import", new Vector2(-1, 0)))
+                OpenTeamCraftImportWindow(manager);
 
             var buttonWidth = (ImGui.GetContentRegionAvail().X - ImGui.GetStyle().ItemSpacing.X) / 2f;
             if (ImGui.Button("Rename", new Vector2(buttonWidth, 0)))
@@ -285,7 +290,8 @@ public sealed class VendorBuyListWindow : Window
             ImGui.Separator();
             ImGui.Spacing();
             ImGui.TextColored(ImGuiColors.DalamudGrey3, "This list is empty.");
-            ImGui.TextColored(ImGuiColors.DalamudGrey3, "Add supported vendor items from the Vendors tab or Materials window to populate it.");
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, "Add supported vendor items from the Vendors tab, Materials window,");
+            ImGui.TextColored(ImGuiColors.DalamudGrey3, "or TeamCraft import to populate it.");
             return;
         }
 

--- a/GatherBuddy/Gui/VulcanUiStyle.cs
+++ b/GatherBuddy/Gui/VulcanUiStyle.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Numerics;
+using Dalamud.Bindings.ImGui;
+
+namespace GatherBuddy.Gui;
+
+internal static class VulcanUiStyle
+{
+    internal static readonly Vector4 PanelBackground = new(0.08f, 0.08f, 0.10f, 1f);
+    internal static readonly Vector4 SurfaceBackground = new(0.15f, 0.15f, 0.18f, 1f);
+    private static readonly Vector4 SurfaceHovered = new(0.18f, 0.18f, 0.22f, 1f);
+    private static readonly Vector4 SurfaceActive = new(0.22f, 0.22f, 0.27f, 1f);
+    private static readonly Vector4 PopupBackground = new(0.10f, 0.10f, 0.13f, 0.98f);
+    private static readonly Vector4 HeaderBackground = new(0.17f, 0.17f, 0.21f, 1f);
+    private static readonly Vector4 HeaderHovered = new(0.23f, 0.23f, 0.29f, 1f);
+    private static readonly Vector4 HeaderActive = new(0.28f, 0.28f, 0.35f, 1f);
+    private static readonly Vector4 BorderColor = new(0.32f, 0.32f, 0.39f, 0.85f);
+    private static readonly Vector4 SeparatorColor = new(0.25f, 0.25f, 0.31f, 1f);
+    private static readonly Vector4 TableHeaderBackground = new(0.12f, 0.12f, 0.15f, 1f);
+
+    internal static IDisposable PushTheme()
+    {
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, SurfaceBackground);
+        ImGui.PushStyleColor(ImGuiCol.FrameBg, SurfaceBackground);
+        ImGui.PushStyleColor(ImGuiCol.FrameBgHovered, SurfaceHovered);
+        ImGui.PushStyleColor(ImGuiCol.FrameBgActive, SurfaceActive);
+        ImGui.PushStyleColor(ImGuiCol.PopupBg, PopupBackground);
+        ImGui.PushStyleColor(ImGuiCol.Header, HeaderBackground);
+        ImGui.PushStyleColor(ImGuiCol.HeaderHovered, HeaderHovered);
+        ImGui.PushStyleColor(ImGuiCol.HeaderActive, HeaderActive);
+        ImGui.PushStyleColor(ImGuiCol.Border, BorderColor);
+        ImGui.PushStyleColor(ImGuiCol.Separator, SeparatorColor);
+        ImGui.PushStyleColor(ImGuiCol.SeparatorHovered, HeaderHovered);
+        ImGui.PushStyleColor(ImGuiCol.SeparatorActive, HeaderActive);
+        ImGui.PushStyleColor(ImGuiCol.TableHeaderBg, TableHeaderBackground);
+        ImGui.PushStyleVar(ImGuiStyleVar.ChildBorderSize, 1f);
+        ImGui.PushStyleVar(ImGuiStyleVar.FrameBorderSize, 1f);
+        ImGui.PushStyleVar(ImGuiStyleVar.PopupBorderSize, 1f);
+        return new StyleScope(13, 3);
+    }
+
+    internal static IDisposable PushPanel()
+    {
+        ImGui.PushStyleColor(ImGuiCol.ChildBg, PanelBackground);
+        return new StyleScope(1, 0);
+    }
+
+    private sealed class StyleScope : IDisposable
+    {
+        private int _colorCount;
+        private int _styleCount;
+
+        public StyleScope(int colorCount, int styleCount)
+        {
+            _colorCount = colorCount;
+            _styleCount = styleCount;
+        }
+
+        public void Dispose()
+        {
+            if (_styleCount > 0)
+            {
+                ImGui.PopStyleVar(_styleCount);
+                _styleCount = 0;
+            }
+            if (_colorCount <= 0)
+                return;
+
+            ImGui.PopStyleColor(_colorCount);
+            _colorCount = 0;
+        }
+    }
+}

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.TeamCraft.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.TeamCraft.cs
@@ -44,7 +44,8 @@ public partial class VulcanWindow
         ImGui.Spacing();
         ImGui.Separator();
         ImGui.Spacing();
-
+        var footerHeight = ImGui.GetFrameHeightWithSpacing() + ImGui.GetStyle().ItemSpacing.Y * 3f + 2f;
+        ImGui.BeginChild("##teamCraftImportContent", new Vector2(0, -footerHeight), false);
         ImGui.Text("List Name:");
         ImGui.SetNextItemWidth(-1);
         ImGui.InputText("##ImportListName", ref _teamCraftListName, 256);
@@ -56,7 +57,9 @@ public partial class VulcanWindow
 
         ImGui.Spacing();
         ImGui.Text("Final Items:");
-        ImGui.InputTextMultiline("##FinalItems", ref _teamCraftFinalItems, 500000, new Vector2(-1, 150));
+        var finalItemsHeight = Math.Max(150f, ImGui.GetContentRegionAvail().Y);
+        ImGui.InputTextMultiline("##FinalItems", ref _teamCraftFinalItems, 500000, new Vector2(-1, finalItemsHeight));
+        ImGui.EndChild();
 
         ImGui.Spacing();
         ImGui.Separator();

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
@@ -313,6 +313,20 @@ public partial class VulcanWindow
             }
         }
 
+        if (ImGui.Selectable("Export to TeamCraft"))
+        {
+            var (exported, error) = GatherBuddy.CraftingListManager.ExportListToTeamCraft(list.ID);
+            if (exported != null)
+            {
+                ImGui.SetClipboardText(exported);
+                GatherBuddy.Log.Information($"[VulcanWindow] Exported list '{list.Name}' to TeamCraft and copied the link to the clipboard");
+            }
+            else if (!string.IsNullOrEmpty(error))
+            {
+                GatherBuddy.Log.Warning($"[VulcanWindow] Failed to export '{list.Name}' to TeamCraft: {error}");
+            }
+        }
+
         ImGui.Separator();
         if (ImGui.Selectable("Delete"))
         {

--- a/GatherBuddy/Gui/VulcanWindow.cs
+++ b/GatherBuddy/Gui/VulcanWindow.cs
@@ -200,6 +200,7 @@ public partial class VulcanWindow : Window, IDisposable
 
     public override void Draw()
     {
+        using var theme = VulcanUiStyle.PushTheme();
         GatherBuddy.ControllerSupport?.TabNavigation.Update(Dalamud.GamepadState, 10);
         
         // Track window focus for controller input blocking

--- a/GatherBuddy/Plugin/IpcSubscribers.cs
+++ b/GatherBuddy/Plugin/IpcSubscribers.cs
@@ -12,7 +12,7 @@ namespace GatherBuddy.Plugin
     internal static class IPCSubscriber
     {
         public static bool IsReady(string pluginName)
-            => ReflectionHelpers.TryGetDalamudPlugin(pluginName, out _);
+            => ReflectionHelpers.IsPluginLoaded(pluginName);
     }
 
     internal static class VNavmesh

--- a/GatherBuddy/Utility/ReflectionHelpers.cs
+++ b/GatherBuddy/Utility/ReflectionHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Reflection;
 using Dalamud.Plugin;
 
@@ -24,6 +25,7 @@ public static class ReflectionHelpers
 
             type = type.BaseType;
         }
+
         return null;
     }
 
@@ -34,26 +36,17 @@ public static class ReflectionHelpers
     {
         try
         {
-            if (!TryGetInstalledPluginEntry(internalName, out var plugin, false))
+            if (!TryGetInstalledPluginEntries(internalName, out var pluginEntries, false))
             {
                 instance = null;
                 return false;
             }
 
-            var type = plugin.GetType().Name == "LocalDevPlugin" ? plugin.GetType().BaseType : plugin.GetType();
-            if (type == null)
-            {
-                instance = null;
-                return false;
-            }
-
-            var pluginInstance = (IDalamudPlugin?)type.GetField("instance", BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(plugin);
-            if (pluginInstance != null)
-            {
-                instance = pluginInstance;
+            if (TrySelectPluginInstance(pluginEntries, IsLoadedPluginEntry, out instance)
+             || TrySelectPluginInstance(pluginEntries, AlwaysMatchPluginEntry, out instance))
                 return true;
-            }
 
+            GatherBuddy.Log.Debug($"[ReflectionHelpers] Found {pluginEntries.Count} matching plugin entries for {internalName}, but no live plugin instance could be resolved.");
             instance = null;
             return false;
         }
@@ -65,9 +58,51 @@ public static class ReflectionHelpers
         }
     }
 
+    internal static bool IsPluginLoaded(string internalName, bool logIfMissing = false)
+    {
+        if (!TryGetInstalledPluginEntries(internalName, out var pluginEntries, logIfMissing))
+            return false;
+
+        var foundReadableLoadState = false;
+        foreach (var pluginEntry in pluginEntries)
+        {
+            if (pluginEntry.GetFoP("IsLoaded") is not bool isLoaded)
+                continue;
+
+            foundReadableLoadState = true;
+            if (isLoaded)
+                return true;
+        }
+
+        if (foundReadableLoadState)
+            return false;
+
+        GatherBuddy.Log.Debug($"[ReflectionHelpers] Matching plugin entries for {internalName} were found, but none exposed IsLoaded. Falling back to plugin instance resolution.");
+        return TryGetDalamudPlugin(internalName, out _);
+    }
+
     internal static bool TryGetInstalledPluginEntry(string internalName, out object? pluginEntry, bool logIfMissing)
     {
-        pluginEntry = null;
+        if (!TryGetInstalledPluginEntries(internalName, out var pluginEntries, logIfMissing))
+        {
+            pluginEntry = null;
+            return false;
+        }
+
+        var selected = TrySelectPluginEntry(pluginEntries, IsLoadedInstalledPluginEntry, out pluginEntry)
+                    || TrySelectPluginEntry(pluginEntries, IsLoadedPluginEntry, out pluginEntry)
+                    || TrySelectPluginEntry(pluginEntries, IsInstalledPluginEntry, out pluginEntry)
+                    || TrySelectPluginEntry(pluginEntries, AlwaysMatchPluginEntry, out pluginEntry);
+
+        if (selected && pluginEntries.Count > 1)
+            GatherBuddy.Log.Debug($"[ReflectionHelpers] Found {pluginEntries.Count} matching plugin entries for {internalName}; selected {DescribePluginEntry(pluginEntry!)}.");
+
+        return selected;
+    }
+
+    private static bool TryGetInstalledPluginEntries(string internalName, out List<object> pluginEntries, bool logIfMissing)
+    {
+        pluginEntries = [];
 
         var pluginManager = GetDalamudService("Dalamud.Plugin.Internal.PluginManager");
         if (pluginManager == null)
@@ -87,15 +122,81 @@ public static class ReflectionHelpers
         {
             var pluginInternalName = plugin.GetFoP<string>("InternalName");
             if (string.Equals(pluginInternalName, internalName, StringComparison.OrdinalIgnoreCase))
-            {
-                pluginEntry = plugin;
-                return true;
-            }
+                pluginEntries.Add(plugin);
         }
+
+        if (pluginEntries.Count > 0)
+            return true;
 
         if (logIfMissing)
             GatherBuddy.Log.Debug($"[ReflectionHelpers] Plugin entry {internalName} was not found in InstalledPlugins.");
+
         return false;
+    }
+
+    private static bool TrySelectPluginEntry(List<object> pluginEntries, Predicate<object> predicate, out object? pluginEntry)
+    {
+        foreach (var candidate in pluginEntries)
+        {
+            if (!predicate(candidate))
+                continue;
+
+            pluginEntry = candidate;
+            return true;
+        }
+
+        pluginEntry = null;
+        return false;
+    }
+
+    private static bool TrySelectPluginInstance(List<object> pluginEntries, Predicate<object> predicate, out IDalamudPlugin? pluginInstance)
+    {
+        foreach (var candidate in pluginEntries)
+        {
+            if (!predicate(candidate))
+                continue;
+
+            if (!TryGetPluginInstance(candidate, out pluginInstance))
+                continue;
+
+            return true;
+        }
+
+        pluginInstance = null;
+        return false;
+    }
+
+    private static bool TryGetPluginInstance(object pluginEntry, out IDalamudPlugin? pluginInstance)
+    {
+        pluginInstance = pluginEntry.GetFoP<IDalamudPlugin>("instance")
+                      ?? pluginEntry.GetFoP<IDalamudPlugin>("Instance")
+                      ?? pluginEntry.GetFoP<IDalamudPlugin>("pluginInstance")
+                      ?? pluginEntry.GetFoP<IDalamudPlugin>("Plugin");
+        return pluginInstance != null;
+    }
+
+    private static bool IsLoadedPluginEntry(object pluginEntry)
+        => pluginEntry.GetFoP("IsLoaded") is bool isLoaded && isLoaded;
+
+    private static bool IsInstalledPluginEntry(object pluginEntry)
+        => !IsLocalDevPlugin(pluginEntry);
+
+    private static bool IsLoadedInstalledPluginEntry(object pluginEntry)
+        => IsLoadedPluginEntry(pluginEntry) && IsInstalledPluginEntry(pluginEntry);
+
+    private static bool AlwaysMatchPluginEntry(object _)
+        => true;
+
+    private static bool IsLocalDevPlugin(object pluginEntry)
+        => string.Equals(pluginEntry.GetType().Name, "LocalDevPlugin", StringComparison.Ordinal)
+         || pluginEntry.GetType().FullName?.Contains("LocalDevPlugin", StringComparison.Ordinal) == true;
+
+    private static string DescribePluginEntry(object pluginEntry)
+    {
+        var kind = IsLocalDevPlugin(pluginEntry) ? "dev" : "installed";
+        var isLoaded = IsLoadedPluginEntry(pluginEntry);
+        var hasInstance = TryGetPluginInstance(pluginEntry, out _);
+        return $"{kind} entry {pluginEntry.GetType().FullName} loaded={isLoaded} instance={hasInstance}";
     }
 
     internal static object? GetDalamudService(string serviceName)

--- a/GatherBuddy/Vulcan/Vendors/VendorBuyListManager.TeamCraftImport.cs
+++ b/GatherBuddy/Vulcan/Vendors/VendorBuyListManager.TeamCraftImport.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using GatherBuddy.Plugin;
+
+namespace GatherBuddy.Vulcan.Vendors;
+
+public sealed partial class VendorBuyListManager
+{
+    public readonly record struct TeamCraftImportResult(VendorBuyListDefinition? List, string? Error, string? Warning);
+    private readonly record struct TeamCraftVendorImportLine(string ItemName, uint Quantity);
+
+    public TeamCraftImportResult ImportTeamCraftList(string text, Guid? destinationListId = null, string? newListName = null)
+    {
+        if (IsBusy)
+        {
+            GatherBuddy.Log.Debug("[VendorBuyListManager] Ignoring TeamCraft vendor import because the manager is busy.");
+            return new TeamCraftImportResult(null, "Vendor lists cannot be modified while a purchase is running.", null);
+        }
+
+        EnsureVendorCachesAvailable();
+        if (!VendorShopResolver.IsInitialized)
+        {
+            GatherBuddy.Log.Debug("[VendorBuyListManager] TeamCraft vendor import requested before vendor data finished loading.");
+            return new TeamCraftImportResult(null, "Vendor data is still loading.", null);
+        }
+
+        VendorBuyListDefinition? destinationList = null;
+        if (destinationListId.HasValue)
+        {
+            destinationList = GetList(destinationListId.Value);
+            if (destinationList == null)
+            {
+                GatherBuddy.Log.Debug($@"[VendorBuyListManager] TeamCraft vendor import requested for missing vendor list {destinationListId.Value}.");
+                return new TeamCraftImportResult(null, "The selected vendor list no longer exists.", null);
+            }
+
+            GatherBuddy.Log.Debug($@"[VendorBuyListManager] TeamCraft vendor import will update existing vendor list '{destinationList.Name}'.");
+        }
+
+        var parsedLines = ParseTeamCraftVendorImport(text);
+        if (parsedLines.Count == 0)
+        {
+            GatherBuddy.Log.Debug("[VendorBuyListManager] TeamCraft vendor import contained no parsable vendor lines.");
+            return new TeamCraftImportResult(null, "No TeamCraft vendor items were found in the pasted text.", null);
+        }
+
+        var resolvedEntries = new List<(VendorShopEntry Entry, VendorNpc Vendor, uint TargetQuantity)>();
+        var unresolvedItems = new List<string>();
+        foreach (var line in parsedLines)
+        {
+            if (!TryResolveTeamCraftImportEntry(line.ItemName, out var entry, out var vendor))
+            {
+                unresolvedItems.Add(line.ItemName);
+                GatherBuddy.Log.Debug($"[VendorBuyListManager] TeamCraft vendor import could not resolve '{line.ItemName}' to a supported vendor route.");
+                continue;
+            }
+
+            var targetQuantity = line.Quantity;
+            resolvedEntries.Add((entry, vendor, targetQuantity));
+            GatherBuddy.Log.Debug(
+                $"[VendorBuyListManager] TeamCraft vendor import resolved {line.Quantity:N0}x {line.ItemName} to {DescribeShopType(entry.ShopType)} vendor '{vendor.Name}' with target {targetQuantity:N0}.");
+        }
+
+        if (resolvedEntries.Count == 0)
+        {
+            var errorMessage = unresolvedItems.Count == 1
+                ? $"Could not resolve '{unresolvedItems[0]}' in the vendor data."
+                : $"Could not resolve any of the {unresolvedItems.Count:N0} pasted items in the vendor data.";
+            GatherBuddy.Log.Debug($"[VendorBuyListManager] TeamCraft vendor import failed: {errorMessage}");
+            return new TeamCraftImportResult(null, errorMessage, null);
+        }
+
+        var createdList = false;
+        var list = destinationList;
+        if (list == null)
+        {
+            var listName = string.IsNullOrWhiteSpace(newListName)
+                ? "Imported from TeamCraft"
+                : newListName.Trim();
+            list = CreateList(listName, false);
+            createdList = true;
+            GatherBuddy.Log.Debug($@"[VendorBuyListManager] TeamCraft vendor import created destination list '{list.Name}'.");
+        }
+        var importedEntryCount = 0;
+        foreach (var resolvedEntry in resolvedEntries)
+        {
+            if (!TrySetResolvedTarget(list, resolvedEntry.Entry, resolvedEntry.Vendor, resolvedEntry.TargetQuantity))
+            {
+                unresolvedItems.Add(resolvedEntry.Entry.ItemName);
+                GatherBuddy.Log.Debug(
+                    $"[VendorBuyListManager] TeamCraft vendor import failed to add {resolvedEntry.Entry.ItemName} to '{list.Name}' after it was resolved.");
+                continue;
+            }
+
+            importedEntryCount++;
+        }
+
+        if (importedEntryCount == 0)
+        {
+            if (createdList)
+            {
+                GatherBuddy.Config.VendorBuyLists.Remove(list);
+                GatherBuddy.Config.Save();
+            }
+            GatherBuddy.Log.Debug("[VendorBuyListManager] TeamCraft vendor import produced no importable entries after resolution.");
+            return new TeamCraftImportResult(null, "No supported vendor routes were available for the pasted items.", null);
+        }
+
+        GatherBuddy.Config.ActiveVendorBuyListId = list.Id;
+        GatherBuddy.Config.Save();
+
+        var warning = BuildTeamCraftImportWarning(unresolvedItems);
+        _statusText = warning == null
+            ? $"Imported {importedEntryCount:N0} TeamCraft vendor item(s) into '{list.Name}'."
+            : $"Imported {importedEntryCount:N0} TeamCraft vendor item(s) into '{list.Name}'. {warning}";
+        GatherBuddy.Log.Information($"[VendorBuyListManager] {_statusText}");
+        return new TeamCraftImportResult(list, null, warning);
+    }
+
+    private static List<TeamCraftVendorImportLine> ParseTeamCraftVendorImport(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+            return [];
+
+        var parsedLines = new Dictionary<string, uint>(StringComparer.OrdinalIgnoreCase);
+        using var reader = new StringReader(text);
+        var sawSectionHeader = false;
+        var inVendorSection = false;
+        string? line;
+        while ((line = reader.ReadLine()) != null)
+        {
+            var trimmedLine = line.Trim();
+            if (trimmedLine.Length == 0)
+                continue;
+
+            if (TryGetTeamCraftSectionHeader(trimmedLine, out var sectionHeader))
+            {
+                sawSectionHeader = true;
+                inVendorSection = sectionHeader.Equals("Vendor", StringComparison.OrdinalIgnoreCase)
+                    || sectionHeader.Equals("Vendors", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (sawSectionHeader && !inVendorSection)
+                continue;
+
+            if (!TryParseTeamCraftVendorImportLine(trimmedLine, out var itemName, out var quantity))
+                continue;
+
+            if (parsedLines.TryGetValue(itemName, out var existingQuantity))
+                parsedLines[itemName] = SaturatingAdd(existingQuantity, quantity);
+            else
+                parsedLines[itemName] = quantity;
+        }
+
+        return parsedLines
+            .Select(kvp => new TeamCraftVendorImportLine(kvp.Key, kvp.Value))
+            .OrderBy(line => line.ItemName, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static bool TryGetTeamCraftSectionHeader(string line, out string header)
+    {
+        header = string.Empty;
+        var separatorIndex = line.LastIndexOf(':');
+        if (separatorIndex < 0 || separatorIndex != line.Length - 1)
+            return false;
+
+        header = line[..separatorIndex].Trim();
+        return header.Length > 0;
+    }
+
+    private static bool TryParseTeamCraftVendorImportLine(string line, out string itemName, out uint quantity)
+    {
+        itemName = string.Empty;
+        quantity = 0;
+
+        var quantitySeparatorIndex = line.IndexOf('x');
+        if (quantitySeparatorIndex <= 0)
+            return false;
+
+        if (!uint.TryParse(line[..quantitySeparatorIndex].Trim(), out quantity) || quantity == 0)
+            return false;
+
+        itemName = line[(quantitySeparatorIndex + 1)..].Trim();
+        return itemName.Length > 0;
+    }
+
+    private static bool TryResolveTeamCraftImportEntry(string itemName, out VendorShopEntry entry, out VendorNpc vendor)
+    {
+        foreach (var candidate in GetTeamCraftImportCandidates(itemName))
+        {
+            var supportedVendors = VendorDevExclusions.GetSelectableNpcs(
+                candidate.Npcs
+                    .Where(npc => VendorPurchaseManager.IsPurchaseSupported(candidate, npc))
+                    .ToList(),
+                "resolving a TeamCraft vendor import item",
+                itemName);
+            if (supportedVendors.Count == 0)
+                continue;
+
+            var preferredVendor = VendorPreferenceHelper.ResolvePreferredNpc(candidate, supportedVendors);
+            if (preferredVendor == null)
+                continue;
+
+            entry = candidate;
+            vendor = preferredVendor;
+            return true;
+        }
+
+        entry = null!;
+        vendor = null!;
+        return false;
+    }
+
+    private static IEnumerable<VendorShopEntry> GetTeamCraftImportCandidates(string itemName)
+        => VendorShopResolver.GilShopEntries
+            .Where(entry => entry.ItemName.Equals(itemName, StringComparison.OrdinalIgnoreCase))
+            .Concat(VendorShopResolver.GcShopEntries
+                .Where(VendorShopResolver.MatchesCurrentGrandCompany)
+                .Where(entry => entry.ItemName.Equals(itemName, StringComparison.OrdinalIgnoreCase)))
+            .Concat(VendorShopResolver.SpecialShopEntries
+                .Where(entry => entry.ItemName.Equals(itemName, StringComparison.OrdinalIgnoreCase)))
+            .OrderBy(GetTeamCraftImportPriority)
+            .ThenBy(entry => entry.Cost)
+            .ThenBy(entry => entry.CurrencyItemId)
+            .ThenBy(entry => entry.ItemId);
+
+    private static int GetTeamCraftImportPriority(VendorShopEntry entry)
+        => entry.ShopType switch
+        {
+            VendorShopType.GilShop           => 0,
+            VendorShopType.GrandCompanySeals => 1,
+            VendorShopType.SpecialCurrency   => 2,
+            _                                => 3,
+        };
+
+    private static string? BuildTeamCraftImportWarning(IReadOnlyList<string> unresolvedItems)
+    {
+        if (unresolvedItems.Count == 0)
+            return null;
+
+        var displayedItems = unresolvedItems
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(3)
+            .ToList();
+        var remainingCount = unresolvedItems
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Skip(displayedItems.Count)
+            .Count();
+        var itemPreview = string.Join(", ", displayedItems);
+        return remainingCount > 0
+            ? $"Skipped {unresolvedItems.Count:N0} item(s): {itemPreview}, and {remainingCount:N0} more."
+            : $"Skipped {unresolvedItems.Count:N0} item(s): {itemPreview}.";
+    }
+}

--- a/GatherBuddy/Vulcan/Vendors/VendorBuyListManager.cs
+++ b/GatherBuddy/Vulcan/Vendors/VendorBuyListManager.cs
@@ -8,7 +8,7 @@ using GatherBuddy.Plugin;
 
 namespace GatherBuddy.Vulcan.Vendors;
 
-public sealed class VendorBuyListManager : IDisposable
+public sealed partial class VendorBuyListManager : IDisposable
 {
     private readonly record struct VendorExecutionGroup(uint NpcId, VendorMenuShopType MenuShopType, uint ShopId);
     public readonly record struct GilShopTargetRequest(uint ItemId, uint TargetQuantity);


### PR DESCRIPTION
Fix for plugin detection taking first found instead of all instances. 
Fix for fishing collectable accept(revert back to previous SeString) 
Fix for quicksynth not skipping when missing materials. 
Gate MaxFishingSpotMinutes logging behind 0 minute setting. 
UI update to force borders better to deal with borderless Look'n'Feels. 
Add TeamCraft Import to Vendor Buy List(Existing or New). 
Fix Crafting List Teamcraft import window not resizing text entry section. 
Add Teamcraft Export to Crafting list editor.
Add Vulcan button to GBR UI.