### PR TITLE
Feature stock keeping crafting lists

### DIFF
--- a/GatherBuddy/Crafting/CraftingExecutionPlan.cs
+++ b/GatherBuddy/Crafting/CraftingExecutionPlan.cs
@@ -9,13 +9,14 @@ public sealed class CraftingExecutionPlan
     private readonly CraftingListDefinition _planningSnapshot;
     private readonly bool _useRetainerCraftableAvailability;
 
-    public int ListId { get; }
-    public string ListName { get; }
-    public int Version { get; private set; }
-    public bool SkipIfEnough { get; }
-    public bool SkipFinalIfEnough { get; }
-    public bool RetainerRestock { get; }
-    public CraftingListPlan ResolvedPlan { get; private set; }
+    public int              ListId            { get; }
+    public string           ListName          { get; }
+    public int              Version           { get; private set; }
+    public bool             SkipIfEnough      { get; }
+    public bool             SkipFinalIfEnough { get; }
+    public bool             RetainerRestock   { get; }
+    public bool             IsStockKeeping    { get; }
+    public CraftingListPlan ResolvedPlan      { get; private set; }
 
     internal List<CraftingListItem> Queue { get; private set; } = [];
     internal List<CraftingListItem> OriginalRecipes { get; private set; } = [];
@@ -37,13 +38,14 @@ public sealed class CraftingExecutionPlan
         bool useRetainerCraftableAvailability,
         CraftingListPlan resolvedPlan)
     {
-        _planningSnapshot = planningSnapshot;
+        _planningSnapshot                 = planningSnapshot;
         _useRetainerCraftableAvailability = useRetainerCraftableAvailability;
-        ListId = planningSnapshot.ID;
-        ListName = planningSnapshot.Name;
-        SkipIfEnough = planningSnapshot.SkipIfEnough;
-        SkipFinalIfEnough = planningSnapshot.SkipFinalIfEnough;
-        RetainerRestock = planningSnapshot.RetainerRestock;
+        ListId                            = planningSnapshot.ID;
+        ListName                          = planningSnapshot.Name;
+        SkipIfEnough                      = planningSnapshot.SkipIfEnough;
+        SkipFinalIfEnough                 = planningSnapshot.SkipFinalIfEnough;
+        RetainerRestock                   = planningSnapshot.RetainerRestock;
+        IsStockKeeping                    = planningSnapshot.StockKeeping;
         ApplyResolvedPlan(resolvedPlan);
     }
 

--- a/GatherBuddy/Crafting/CraftingListDefinition.cs
+++ b/GatherBuddy/Crafting/CraftingListDefinition.cs
@@ -95,6 +95,7 @@ public class CraftingListDefinition
             RepairPercent = RepairPercent,
             RetainerRestock = RetainerRestock,
             Ephemeral = Ephemeral,
+            StockKeeping = StockKeeping
         };
 
         foreach (var recipe in Recipes)

--- a/GatherBuddy/Crafting/CraftingListDefinition.cs
+++ b/GatherBuddy/Crafting/CraftingListDefinition.cs
@@ -7,32 +7,32 @@ namespace GatherBuddy.Crafting;
 
 public class CraftingListDefinition
 {
-    public int ID { get; set; }
-    public string Name { get; set; } = string.Empty;
-    public string Description { get; set; } = string.Empty;
-    public string FolderPath { get; set; } = string.Empty;
-    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
-    public List<CraftingListItem> Recipes { get; set; } = new();
-    public List<uint> ExpandedList { get; set; } = new();
-    public CraftingListConsumableSettings Consumables { get; set; } = new();
-    public Dictionary<uint, ListItemOptions> PrecraftOptions { get; set; } = new();
-    public Dictionary<uint, RecipeCraftSettings> PrecraftCraftSettings { get; set; } = new();
-    public string? DefaultPrecraftMacroId { get; set; }
-    public string? DefaultFinalMacroId { get; set; }
-    public SolverOverrideMode DefaultPrecraftSolverOverride { get; set; } = SolverOverrideMode.Default;
-    public SolverOverrideMode DefaultFinalSolverOverride { get; set; } = SolverOverrideMode.Default;
-    
-    public Dictionary<uint, uint> PrecraftRecipeOverrides { get; set; } = new();
-    public bool SkipIfEnough { get; set; } = false;
-    public bool SkipFinalIfEnough { get; set; } = false;
-    public bool QuickSynthAll { get; set; } = false;
-    public bool QuickSynthAllPreferNQ { get; set; } = false;
-    public bool QuickSynthAllPrecraftsOnly { get; set; } = false;
-    public bool Materia { get; set; } = false;
-    public bool Repair { get; set; } = false;
-    public int RepairPercent { get; set; } = 50;
-    public bool RetainerRestock { get; set; } = false;
-    public bool Ephemeral { get; set; } = false;
+    public int                                   ID                            { get; set; }
+    public string                                Name                          { get; set; } = string.Empty;
+    public string                                Description                   { get; set; } = string.Empty;
+    public string                                FolderPath                    { get; set; } = string.Empty;
+    public DateTime                              CreatedAt                     { get; set; } = DateTime.UtcNow;
+    public List<CraftingListItem>                Recipes                       { get; set; } = new();
+    public List<uint>                            ExpandedList                  { get; set; } = new();
+    public CraftingListConsumableSettings        Consumables                   { get; set; } = new();
+    public Dictionary<uint, ListItemOptions>     PrecraftOptions               { get; set; } = new();
+    public Dictionary<uint, RecipeCraftSettings> PrecraftCraftSettings         { get; set; } = new();
+    public string?                               DefaultPrecraftMacroId        { get; set; }
+    public string?                               DefaultFinalMacroId           { get; set; }
+    public SolverOverrideMode                    DefaultPrecraftSolverOverride { get; set; } = SolverOverrideMode.Default;
+    public SolverOverrideMode                    DefaultFinalSolverOverride    { get; set; } = SolverOverrideMode.Default;
+    public Dictionary<uint, uint>                PrecraftRecipeOverrides       { get; set; } = new();
+    public bool                                  SkipIfEnough                  { get; set; } = false;
+    public bool                                  SkipFinalIfEnough             { get; set; } = false;
+    public bool                                  QuickSynthAll                 { get; set; } = false;
+    public bool                                  QuickSynthAllPreferNQ         { get; set; } = false;
+    public bool                                  QuickSynthAllPrecraftsOnly    { get; set; } = false;
+    public bool                                  Materia                       { get; set; } = false;
+    public bool                                  Repair                        { get; set; } = false;
+    public int                                   RepairPercent                 { get; set; } = 50;
+    public bool                                  RetainerRestock               { get; set; } = false;
+    public bool                                  Ephemeral                     { get; set; } = false;
+    public bool                                  StockKeeping                  { get; set; } = false;
 
     public bool ShouldApplyQuickSynthAllOverrides(bool isOriginalRecipe)
         => QuickSynthAll && (!QuickSynthAllPrecraftsOnly || !isOriginalRecipe);

--- a/GatherBuddy/Crafting/CraftingListManager.cs
+++ b/GatherBuddy/Crafting/CraftingListManager.cs
@@ -23,7 +23,7 @@ public class CraftingListManager
     {
         return !_lists.Any(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase) && (!excludeId.HasValue || x.ID != excludeId.Value));
     }
-    public CraftingListDefinition CreateNewList(string name, bool ephemeral = false, string? folderPath = null)
+    public CraftingListDefinition CreateNewList(string name, bool ephemeral = false, bool stockkeeping = false, string? folderPath = null)
     {
         if (!IsNameUnique(name))
         {
@@ -52,7 +52,8 @@ public class CraftingListManager
             ID = proposedId,
             Name = name,
             FolderPath = normalizedFolderPath,
-            Ephemeral = ephemeral
+            Ephemeral = ephemeral,
+            StockKeeping = stockkeeping
         };
         
         _lists.Add(list);

--- a/GatherBuddy/Crafting/CraftingQueueProcessor.cs
+++ b/GatherBuddy/Crafting/CraftingQueueProcessor.cs
@@ -1289,6 +1289,13 @@ public class CraftingQueueProcessor
         var combinedItems = new Dictionary<uint, int>(MaterialTargets);
         foreach (var (k, v) in RetainerPrecraftTargets)
         {
+            if (_executionPlan != null)
+            {
+                var isOriginalRecipe = _executionPlan.OriginalRecipes.Any(x => x.RecipeId == k);
+                if (_executionPlan.IsStockKeeping && isOriginalRecipe)
+                    continue; //Skip withdrawal of Original Recipe Items for StockKeeping Lists
+            }
+
             if (combinedItems.ContainsKey(k)) combinedItems[k] += v;
             else combinedItems[k] = v;
         }

--- a/GatherBuddy/Gui/CraftingListEditor.cs
+++ b/GatherBuddy/Gui/CraftingListEditor.cs
@@ -529,23 +529,13 @@ public class CraftingListEditor
 
         ImGui.Checkbox("Show Precrafts##sp", ref _showPrecrafts);
 
-        if (_list.StockKeeping)
+        using (ImRaii.Disabled(_list.StockKeeping))
         {
-            ImGui.BeginDisabled();
-            try
-            {
-                _list.SkipIfEnough      = true;
-                _list.SkipFinalIfEnough = true;
-                DrawSkipIfEnoughCheckBox();
-            }
-            finally
-            {
-                ImGui.EndDisabled();
-            }
-        }
-        else
+            _list.SkipIfEnough      = _list.StockKeeping || _list.SkipIfEnough;
+            _list.SkipFinalIfEnough = _list.StockKeeping || _list.SkipFinalIfEnough;
+            
             DrawSkipIfEnoughCheckBox();
-
+        }
         var quickSynthAll = _list.QuickSynthAll;
         if (ImGui.Checkbox("Quick Synth All##qsa", ref quickSynthAll))
         {
@@ -596,7 +586,7 @@ public class CraftingListEditor
         }
 
         var allaganEnabled = AllaganTools.Enabled;
-        using (ImRaii.Disabled(!allaganEnabled))
+        using (ImRaii.Disabled(!allaganEnabled || _list.StockKeeping))
         {
             var retainerRestock = _list.RetainerRestock || _list.StockKeeping;
             if (ImGui.Checkbox("Restock from Retainers##rrr", ref retainerRestock))

--- a/GatherBuddy/Gui/CraftingListEditor.cs
+++ b/GatherBuddy/Gui/CraftingListEditor.cs
@@ -529,34 +529,22 @@ public class CraftingListEditor
 
         ImGui.Checkbox("Show Precrafts##sp", ref _showPrecrafts);
 
-        var skipIfEnough = _list.SkipIfEnough;
-        if (ImGui.Checkbox("Skip if Already Have Enough##sie", ref skipIfEnough))
+        if (_list.StockKeeping)
         {
-            _list.SkipIfEnough    = skipIfEnough;
-            _cachedQueueValid     = false;
-            InvalidateMaterialCaches();
-            InvalidatePresentationCaches();
-            GatherBuddy.CraftingListManager.SaveList(_list);
-            TriggerQueueRegeneration();
-            RefreshInventoryCounts();
-        }
-
-        if (_list.SkipIfEnough)
-        {
-            ImGui.Indent();
-            var skipFinalIfEnough = _list.SkipFinalIfEnough;
-            if (ImGui.Checkbox("Include Final Crafts##sife", ref skipFinalIfEnough))
+            ImGui.BeginDisabled();
+            try
             {
-                _list.SkipFinalIfEnough = skipFinalIfEnough;
-                _cachedQueueValid       = false;
-                InvalidatePresentationCaches();
-                GatherBuddy.CraftingListManager.SaveList(_list);
-                TriggerQueueRegeneration();
+                _list.SkipIfEnough      = true;
+                _list.SkipFinalIfEnough = true;
+                DrawSkipIfEnoughCheckBox();
             }
-            if (ImGui.IsItemHovered())
-                ImGui.SetTooltip("Also reduce final crafts based on how many you already have. Useful for resuming an interrupted list.");
-            ImGui.Unindent();
+            finally
+            {
+                ImGui.EndDisabled();
+            }
         }
+        else
+            DrawSkipIfEnoughCheckBox();
 
         var quickSynthAll = _list.QuickSynthAll;
         if (ImGui.Checkbox("Quick Synth All##qsa", ref quickSynthAll))
@@ -610,7 +598,7 @@ public class CraftingListEditor
         var allaganEnabled = AllaganTools.Enabled;
         using (ImRaii.Disabled(!allaganEnabled))
         {
-            var retainerRestock = _list.RetainerRestock;
+            var retainerRestock = _list.RetainerRestock || _list.StockKeeping;
             if (ImGui.Checkbox("Restock from Retainers##rrr", ref retainerRestock))
             {
                 _list.RetainerRestock = retainerRestock;
@@ -690,7 +678,39 @@ public class CraftingListEditor
 
         ImGui.EndChild();
     }
-    
+
+    private void DrawSkipIfEnoughCheckBox()
+    {
+        var skipIfEnough = _list.SkipIfEnough;
+        if (ImGui.Checkbox("Skip if Already Have Enough##sie", ref skipIfEnough))
+        {
+            _list.SkipIfEnough = skipIfEnough;
+            _cachedQueueValid  = false;
+            InvalidateMaterialCaches();
+            InvalidatePresentationCaches();
+            GatherBuddy.CraftingListManager.SaveList(_list);
+            TriggerQueueRegeneration();
+            RefreshInventoryCounts();
+        }
+
+        if (_list.SkipIfEnough)
+        {
+            ImGui.Indent();
+            var skipFinalIfEnough = _list.SkipFinalIfEnough;
+            if (ImGui.Checkbox("Include Final Crafts##sife", ref skipFinalIfEnough))
+            {
+                _list.SkipFinalIfEnough = skipFinalIfEnough;
+                _cachedQueueValid       = false;
+                InvalidatePresentationCaches();
+                GatherBuddy.CraftingListManager.SaveList(_list);
+                TriggerQueueRegeneration();
+            }
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Also reduce final crafts based on how many you already have. Useful for resuming an interrupted list.");
+            ImGui.Unindent();
+        }
+    }
+
     private void DrawDetailsPane()
     {
         ImGui.TextColored(ImGuiColors.DalamudYellow, "List Info");

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
@@ -142,7 +142,7 @@ public partial class VulcanWindow
         ImGui.Spacing();
         
         //TODO: Need an OptionBox instead of two Checkboxes
-        ImGui.Checkbox("Ephemeral##newListStockKeeping", ref _newListStockKeeping);
+        ImGui.Checkbox("StockKeeping##newListStockKeeping", ref _newListStockKeeping);
         if (ImGui.IsItemHovered())
             ImGui.SetTooltip("This list will check if you have enough of the specified materials in your Retainer without withdrawing any. \nFor when you always want to have X of all Lumber and easily recraft what you used up.");
 

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
@@ -12,6 +12,7 @@ public partial class VulcanWindow
 {
     private string  _newListName         = string.Empty;
     private bool    _newListEphemeral    = false;
+    private bool    _newListStockKeeping = false;
     private string  _newListFolderPath   = string.Empty;
     private uint?   _newListRecipeId     = null;
     private string  _newListRecipeName   = string.Empty;
@@ -23,11 +24,12 @@ public partial class VulcanWindow
 
     private void ResetCreateListPopupState()
     {
-        _newListName = string.Empty;
-        _newListEphemeral = false;
-        _newListFolderPath = string.Empty;
-        _newListRecipeId = null;
-        _newListRecipeName = string.Empty;
+        _newListName         = string.Empty;
+        _newListEphemeral    = false;
+        _newListStockKeeping = false;
+        _newListFolderPath   = string.Empty;
+        _newListRecipeId     = null;
+        _newListRecipeName   = string.Empty;
         _openCreateListPopup = false;
     }
 
@@ -137,10 +139,19 @@ public partial class VulcanWindow
         ImGui.Spacing();
         ImGui.Separator();
         ImGui.Spacing();
+        
+        //TODO: Need an OptionBox instead of two Checkboxes
+        ImGui.Checkbox("Ephemeral##newListStockKeeping", ref _newListStockKeeping);
+        if (ImGui.IsItemHovered())
+            ImGui.SetTooltip("This list will check if you have enough of the specified materials in your Retainer without withdrawing any. \nFor when you always want to have X of all Lumber and easily recraft what you used up.");
+
+        ImGui.Spacing();
+        ImGui.Separator();
+        ImGui.Spacing();
 
         if (ImGui.Button("Create", new Vector2(100, 0)) && !string.IsNullOrWhiteSpace(_newListName))
         {
-            var newList = GatherBuddy.CraftingListManager.CreateNewList(_newListName, _newListEphemeral, _newListFolderPath);
+            var newList = GatherBuddy.CraftingListManager.CreateNewList(_newListName, _newListEphemeral, _newListStockKeeping, _newListFolderPath);
             if (_newListRecipeId.HasValue)
             {
                 newList.AddRecipe(_newListRecipeId.Value, 1);

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.Popups.cs
@@ -70,6 +70,7 @@ public partial class VulcanWindow
         {
             if (ImGui.Button("Import", new Vector2(120, 0)))
             {
+                //TODO: Special Import Logic for StockKeeping Lists needed?
                 var (imported, error) = GatherBuddy.CraftingListManager.ImportList(_importListText);
                 if (imported != null)
                 {

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
@@ -111,19 +111,15 @@ public partial class VulcanWindow
                         }
                         else if (_editingList.StockKeeping)
                         {
-                            ImGui.BeginDisabled();
-                            try
+                            using (ImRaii.Enabled())
                             {
                                 var tmpBool = true;
-                                ImGui.Checkbox("StockKeeping##listHeaderStockKeeping", ref tmpBool); //Not planned in the first place to disable the StockKeeping Option
-                                
+                                ImGui.Checkbox("StockKeeping##listHeaderStockKeeping",
+                                    ref tmpBool); //Not planned in the first place to disable the StockKeeping Option
+
                                 if (ImGui.IsItemHovered())
                                     ImGui.SetTooltip(
                                         "This list will check if you have enough of the specified materials in your Retainer without withdrawing any. \nFor when you always want to have X of all Lumber and easily recraft what you used up.");
-                            }
-                            finally
-                            {
-                                ImGui.EndDisabled();
                             }
                         }
                         else

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
@@ -111,7 +111,7 @@ public partial class VulcanWindow
                         }
                         else if (_editingList.StockKeeping)
                         {
-                            using (ImRaii.Enabled())
+                            using (ImRaii.Disabled(_editingList.StockKeeping))
                             {
                                 var tmpBool = true;
                                 ImGui.Checkbox("StockKeeping##listHeaderStockKeeping",

--- a/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
+++ b/GatherBuddy/Gui/VulcanWindow.CraftingListsTab.cs
@@ -109,6 +109,23 @@ public partial class VulcanWindow
                             if (ImGui.IsItemHovered())
                                 ImGui.SetTooltip("Automatically delete this list after crafting completes. Has no effect if stopped manually.");
                         }
+                        else if (_editingList.StockKeeping)
+                        {
+                            ImGui.BeginDisabled();
+                            try
+                            {
+                                var tmpBool = true;
+                                ImGui.Checkbox("StockKeeping##listHeaderStockKeeping", ref tmpBool); //Not planned in the first place to disable the StockKeeping Option
+                                
+                                if (ImGui.IsItemHovered())
+                                    ImGui.SetTooltip(
+                                        "This list will check if you have enough of the specified materials in your Retainer without withdrawing any. \nFor when you always want to have X of all Lumber and easily recraft what you used up.");
+                            }
+                            finally
+                            {
+                                ImGui.EndDisabled();
+                            }
+                        }
                         else
                         {
                             ImGui.TextColored(ImGuiColors.DalamudGrey3, "Crafting List");


### PR DESCRIPTION
Add Stock Keeping Crafting Lists, basically Pin Retainer Restock and SkipFinal Products, but without actually Withdrawing the Final Product.
The Goal is to have a list where you add for example 100 of each lumber and you can start the List every couple of days to recraft all the Lumber used in the meantime.