### PR TITLE
Fix AutoRetainer multi-mode deadlock on timed nodes

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -2363,12 +2363,16 @@ namespace GatherBuddy.AutoGather
         {
             try
             {
-                // Only short-circuit on timed nodes when AR MultiMode has NOT yet been started by GBR.
-                // If GBR already triggered AR and (likely) switched characters, bailing here strands
-                // both: AR's pathing to the retainer bell gets interrupted and GBR tries to gather a
-                // node that lives on the original character's territory. Stay in the wait state so
-                // the relog-back branch below can run once AR finishes.
-                if (GatherBuddy.Config.AutoGatherConfig.AutoRetainerDelayForTimedNodes && !_autoRetainerMultiModeEnabled)
+                // Only short-circuit on timed nodes when no AR cycle is committed AND no relog is
+                // pending. `_autoRetainerMultiModeEnabled` covers the active AR phase; once AR
+                // finishes, the else-branch below clears it _before_ the Lifestream relog completes,
+                // so we also have to gate on `_originalCharacterNameWorld` (cleared only after the
+                // player is confirmed back on the original character). Without this second gate, a
+                // timed-node window opening during the relog would bail out of the wait state and
+                // leave GBR gathering on the wrong character.
+                if (GatherBuddy.Config.AutoGatherConfig.AutoRetainerDelayForTimedNodes
+                    && !_autoRetainerMultiModeEnabled
+                    && string.IsNullOrEmpty(_originalCharacterNameWorld))
                 {
                     if (_currentGatherTarget != null)
                     {

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -2363,7 +2363,12 @@ namespace GatherBuddy.AutoGather
         {
             try
             {
-                if (GatherBuddy.Config.AutoGatherConfig.AutoRetainerDelayForTimedNodes)
+                // Only short-circuit on timed nodes when AR MultiMode has NOT yet been started by GBR.
+                // If GBR already triggered AR and (likely) switched characters, bailing here strands
+                // both: AR's pathing to the retainer bell gets interrupted and GBR tries to gather a
+                // node that lives on the original character's territory. Stay in the wait state so
+                // the relog-back branch below can run once AR finishes.
+                if (GatherBuddy.Config.AutoGatherConfig.AutoRetainerDelayForTimedNodes && !_autoRetainerMultiModeEnabled)
                 {
                     if (_currentGatherTarget != null)
                     {
@@ -2373,13 +2378,13 @@ namespace GatherBuddy.AutoGather
                             return false;
                         }
                     }
-                    
+
                     var nextItem = _activeItemList.GetNextOrDefault();
                     if (nextItem != default)
                     {
                         if (nextItem.Node?.NodeType is NodeType.Legendary or NodeType.Unspoiled)
                         {
-                            if (nextItem.Time.InRange(AdjustedServerTime) && 
+                            if (nextItem.Time.InRange(AdjustedServerTime) &&
                                 !_activeItemList.DebugVisitedTimedLocations.ContainsKey(nextItem.Node))
                             {
                                 return false;


### PR DESCRIPTION
## Summary
- When **Wait for AutoRetainer Multi-mode** is on and a retainer belongs to a character other than the one currently gathering, GBR triggers AR multi-mode and AR logs into the other character. If a timed (Legendary/Unspoiled) node window opens while we are on that other character, `ShouldWaitForAutoRetainer` short-circuits with `return false` because of `AutoRetainerDelayForTimedNodes`. That early return bypasses the relog-back branch, so GBR tries to gather a node that lives on the original character's territory while AR is still pathing to the retainer bell, and both lock up.
- Gate the short-circuit on `!_autoRetainerMultiModeEnabled` so it only applies *before* GBR has committed to an AR cycle. Once a cycle is in flight, GBR stays in the wait state and the existing state machine completes AR's work and relogs back via Lifestream.
- One-condition change in `GatherBuddy/AutoGather/AutoGather.cs`; no behavioural change to the pre-cycle case (timed node already in range → still skip AR), no change to the relog-back path.

## Test plan
- [x] On a multi-character setup, enable `Wait for AutoRetainer Multi-mode` and `Delay AutoRetainer for timed nodes`.
- [x] Configure at least one retainer on a non-active character so its venture finishes inside the threshold window.
- [x] Start AutoGather on a list containing a Legendary or Unspoiled node whose window will open during the AR cycle.
- [x] Expected: AR multi-mode runs to completion on the other character, GBR relogs back to the original character, then proceeds to gather the timed node. Neither GBR nor AR should stall.
- [x] Regression check: starting AutoGather *while* a timed node is already in range with retainers ready should still short-circuit AR (i.e. gather first, retainers after).