### PR TITLE
Guard null before list removal & switch to Verbose log for `isFishing`

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -443,7 +443,8 @@ namespace GatherBuddy.AutoGather
                             VisitedNodes.Add(targetNode.BaseId);
                     }
                 }
-                _plugin.AutoGatherListsManager.RemoveCompletedItemFromLists(gatherTarget.Item);
+                if (gatherTarget.Item != null)
+                    _plugin.AutoGatherListsManager.RemoveCompletedItemFromLists(gatherTarget.Item);
                 // Unset the current gather target when leaving the node
                 _currentGatherTarget = null;
                 ResetPendingFishingTargetChange();
@@ -1348,7 +1349,7 @@ namespace GatherBuddy.AutoGather
             {
                 if (GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes > 0)
                 {
-                    GatherBuddy.Log.Debug($"[AutoGather] IsFishing block entered, timer will be checked. MaxFishingSpotMinutes={GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes}, Expiration={fishingSpotData.Expiration}");
+                    GatherBuddy.Log.Verbose($"[AutoGather] IsFishing block entered, timer will be checked. MaxFishingSpotMinutes={GatherBuddy.Config.AutoGatherConfig.MaxFishingSpotMinutes}, Expiration={fishingSpotData.Expiration}");
                 }
                 if (_fishWaryDetected)
                 {


### PR DESCRIPTION
Makes 2 small improvements:

- Use `Verbose` instead of `Debug` to avoid spamming Dalamud log console with prints of `isFishing` check statements.
- Add null check before removing completed items from list. This was causing the ENTIRE auto-gather function to fail because it would attempt to remove even if the list was empty/no items matched.