### PR TITLE
Add owner-scoped cooperative AutoGather pause leases

### DIFF
--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -202,24 +202,47 @@ namespace GatherBuddy.AutoGather
         public TaskManager                TaskManager { get; }
 
         private           bool             _enabled { get; set; } = false;
+        private readonly object             _pauseRequestGate = new();
         private readonly HashSet<string>    _pauseRequests = new(StringComparer.Ordinal);
         private bool                        _pauseEffective;
+        private bool?                       _waitingBeforePause;
 
         public void SetPauseRequest(string owner, bool paused)
         {
             if (string.IsNullOrWhiteSpace(owner))
                 throw new ArgumentException("A pause-request owner is required.", nameof(owner));
 
-            if (paused)
-                _pauseRequests.Add(owner);
-            else
-                _pauseRequests.Remove(owner);
-            if (_pauseRequests.Count == 0)
-                _pauseEffective = false;
+            lock (_pauseRequestGate)
+            {
+                if (paused)
+                    _pauseRequests.Add(owner);
+                else
+                    _pauseRequests.Remove(owner);
+            }
         }
 
         public bool IsPauseRequestEffective(string owner)
-            => !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+        {
+            lock (_pauseRequestGate)
+                return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+        }
+
+        private string[] PauseRequestOwners()
+        {
+            lock (_pauseRequestGate)
+                return _pauseRequests.OrderBy(owner => owner, StringComparer.Ordinal).ToArray();
+        }
+
+        private bool SetPauseEffective(bool effective)
+        {
+            lock (_pauseRequestGate)
+            {
+                if (_pauseEffective == effective)
+                    return false;
+                _pauseEffective = effective;
+                return true;
+            }
+        }
 
         public bool Waiting
         {
@@ -498,34 +521,33 @@ namespace GatherBuddy.AutoGather
                 return;
             }
 
-            if (_pauseRequests.Count > 0)
+            var pauseOwners = PauseRequestOwners();
+            if (pauseOwners.Length > 0)
             {
                 if (IsGathering)
                 {
-                    AutoStatus = $"Pausing for {string.Join(", ", _pauseRequests)} after the current gathering interaction...";
+                    AutoStatus = $"Pausing for {string.Join(", ", pauseOwners)} after the current gathering interaction...";
                     if (Player.Job == 18 && IsFishing)
                         QueueQuitFishingTasks();
-                    else
-                        CloseGatheringAddons();
-                    _pauseEffective = false;
+                    SetPauseEffective(false);
                     return;
                 }
 
                 StopNavigation();
-                if (!_pauseEffective)
+                if (SetPauseEffective(true))
                 {
+                    _waitingBeforePause = Waiting;
                     Waiting = true;
                     _plugin.Ipc.AutoGatherWaiting();
                 }
-                _pauseEffective = true;
-                AutoStatus = $"Paused for {string.Join(", ", _pauseRequests)}";
+                AutoStatus = $"Paused for {string.Join(", ", pauseOwners)}";
                 return;
             }
 
-            if (_pauseEffective)
+            if (SetPauseEffective(false))
             {
-                _pauseEffective = false;
-                Waiting = false;
+                Waiting = _waitingBeforePause ?? false;
+                _waitingBeforePause = null;
             }
 
             if (!_homeWorldWarning && !Functions.OnHomeWorld())

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -202,6 +202,24 @@ namespace GatherBuddy.AutoGather
         public TaskManager                TaskManager { get; }
 
         private           bool             _enabled { get; set; } = false;
+        private readonly HashSet<string>    _pauseRequests = new(StringComparer.Ordinal);
+        private bool                        _pauseEffective;
+
+        public void SetPauseRequest(string owner, bool paused)
+        {
+            if (string.IsNullOrWhiteSpace(owner))
+                throw new ArgumentException("A pause-request owner is required.", nameof(owner));
+
+            if (paused)
+                _pauseRequests.Add(owner);
+            else
+                _pauseRequests.Remove(owner);
+            if (_pauseRequests.Count == 0)
+                _pauseEffective = false;
+        }
+
+        public bool IsPauseRequestEffective(string owner)
+            => !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
 
         public bool Waiting
         {
@@ -478,6 +496,36 @@ namespace GatherBuddy.AutoGather
             {
                 //GatherBuddy.Log.Verbose("TaskManager has tasks, skipping DoAutoGather");
                 return;
+            }
+
+            if (_pauseRequests.Count > 0)
+            {
+                if (IsGathering)
+                {
+                    AutoStatus = $"Pausing for {string.Join(", ", _pauseRequests)} after the current gathering interaction...";
+                    if (Player.Job == 18 && IsFishing)
+                        QueueQuitFishingTasks();
+                    else
+                        CloseGatheringAddons();
+                    _pauseEffective = false;
+                    return;
+                }
+
+                StopNavigation();
+                if (!_pauseEffective)
+                {
+                    Waiting = true;
+                    _plugin.Ipc.AutoGatherWaiting();
+                }
+                _pauseEffective = true;
+                AutoStatus = $"Paused for {string.Join(", ", _pauseRequests)}";
+                return;
+            }
+
+            if (_pauseEffective)
+            {
+                _pauseEffective = false;
+                Waiting = false;
             }
 
             if (!_homeWorldWarning && !Functions.OnHomeWorld())

--- a/GatherBuddy/AutoGather/AutoGather.cs
+++ b/GatherBuddy/AutoGather/AutoGather.cs
@@ -202,8 +202,9 @@ namespace GatherBuddy.AutoGather
         public TaskManager                TaskManager { get; }
 
         private           bool             _enabled { get; set; } = false;
+        private static readonly TimeSpan    PauseRequestLifetime = TimeSpan.FromMinutes(10);
         private readonly object             _pauseRequestGate = new();
-        private readonly HashSet<string>    _pauseRequests = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, DateTime> _pauseRequests = new(StringComparer.Ordinal);
         private bool                        _pauseEffective;
         private bool?                       _waitingBeforePause;
 
@@ -215,7 +216,7 @@ namespace GatherBuddy.AutoGather
             lock (_pauseRequestGate)
             {
                 if (paused)
-                    _pauseRequests.Add(owner);
+                    _pauseRequests[owner] = DateTime.UtcNow.Add(PauseRequestLifetime);
                 else
                     _pauseRequests.Remove(owner);
             }
@@ -224,13 +225,26 @@ namespace GatherBuddy.AutoGather
         public bool IsPauseRequestEffective(string owner)
         {
             lock (_pauseRequestGate)
-                return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.Contains(owner) && _pauseEffective;
+            {
+                PruneExpiredPauseRequests();
+                return !string.IsNullOrWhiteSpace(owner) && _pauseRequests.ContainsKey(owner) && _pauseEffective;
+            }
         }
 
         private string[] PauseRequestOwners()
         {
             lock (_pauseRequestGate)
-                return _pauseRequests.OrderBy(owner => owner, StringComparer.Ordinal).ToArray();
+            {
+                PruneExpiredPauseRequests();
+                return _pauseRequests.Keys.OrderBy(owner => owner, StringComparer.Ordinal).ToArray();
+            }
+        }
+
+        private void PruneExpiredPauseRequests()
+        {
+            var now = DateTime.UtcNow;
+            foreach (var owner in _pauseRequests.Where(request => request.Value <= now).Select(request => request.Key).ToArray())
+                _pauseRequests.Remove(owner);
         }
 
         private bool SetPauseEffective(bool effective)

--- a/GatherBuddy/Plugin/GatherBuddyIpc.cs
+++ b/GatherBuddy/Plugin/GatherBuddyIpc.cs
@@ -5,7 +5,7 @@ namespace GatherBuddy.Plugin;
 
 public sealed class GatherBuddyIpc : IDisposable
 {
-    public const int IpcVersion = 2;
+    public const int IpcVersion = 3;
 
     private readonly GatherBuddy _plugin;
 
@@ -42,6 +42,14 @@ public sealed class GatherBuddyIpc : IDisposable
     [EzIPC]
     public bool IsAutoGatherWaiting()
         => GatherBuddy.AutoGather.Waiting;
+
+    [EzIPC]
+    public void SetAutoGatherPauseRequest(string owner, bool paused)
+        => GatherBuddy.AutoGather.SetPauseRequest(owner, paused);
+
+    [EzIPC]
+    public bool IsAutoGatherPauseRequestEffective(string owner)
+        => GatherBuddy.AutoGather.IsPauseRequestEffective(owner);
 
     [EzIPCEvent]
     public Action AutoGatherWaiting;


### PR DESCRIPTION
## Summary
- add IPC v3 endpoints for named AutoGather pause requests and effective-state checks
- finish the current indivisible task or gathering interaction, stop navigation at the next safe boundary, and preserve the active list
- restore the prior waiting state on release and expire abandoned leases after ten minutes

## Why
The existing SetAutoGatherEnabled(false) API aborts TaskManager work and clears active AutoGather state, so consumers cannot safely borrow movement or UI ownership and later resume the user's plan.

## Validation
- dotnet build GatherBuddy/GatherBuddy.csproj --no-restore
- verified the focused project builds with zero errors (existing upstream warnings remain)