### PR TITLE
Add Artisan premade list support to Auto-Gather import

### DIFF
--- a/GatherBuddy/AutoGather/Helpers/Reflection.cs
+++ b/GatherBuddy/AutoGather/Helpers/Reflection.cs
@@ -31,7 +31,19 @@ namespace GatherBuddy.AutoGather.Helpers
             public bool TouchArtisanAssembly
                 => ReflectionHelpers.TryGetDalamudPlugin("Artisan", out ArtisanAssemblyInstance);
 
-            public Dictionary<int, string> GetArtisanListNames()
+            private System.Collections.IList? GetArtisanCraftingLists(bool premade)
+            {
+#pragma warning disable CS8600, CS8602, CS8604, CS8605 // Null handled by callers' catch blocks
+                // User lists live in Config.NewCraftingLists, premade (quest-derived) lists in PremadeLists.PremadeCraftingLists.
+                // Both are List<NewCraftingList>; Artisan's own IPC treats them as peers.
+                var container = premade
+                    ? ArtisanAssemblyInstance.GetFoP("PremadeLists")
+                    : ArtisanAssemblyInstance.GetFoP("Config");
+                return (System.Collections.IList?)container?.GetFoP(premade ? "PremadeCraftingLists" : "NewCraftingLists");
+#pragma warning restore CS8600, CS8602, CS8604, CS8605
+            }
+
+            public Dictionary<int, string> GetArtisanListNames(bool premade = false)
             {
                 Dictionary<int, string> listNames = [];
                 try
@@ -39,7 +51,13 @@ namespace GatherBuddy.AutoGather.Helpers
                     if (TouchArtisanAssembly)
                     {
 #pragma warning disable CS8600, CS8602, CS8604, CS8605 // Null handled by catch block
-                        System.Collections.IList artisanCraftingLists = (System.Collections.IList)ArtisanAssemblyInstance.GetFoP("Config").GetFoP("NewCraftingLists");
+                        var artisanCraftingLists = GetArtisanCraftingLists(premade);
+                        if (artisanCraftingLists == null)
+                        {
+                            GatherBuddy.Log.Debug($"Could not resolve Artisan {(premade ? "premade" : "user")} crafting lists.");
+                            return listNames;
+                        }
+
                         foreach (var list in artisanCraftingLists)
                         {
                             var name = list.GetFoP("Name").ToString();
@@ -58,19 +76,19 @@ namespace GatherBuddy.AutoGather.Helpers
                 }
             }
 
-            public void StartArtisanImport(KeyValuePair<int, string> listKvp)
+            public void StartArtisanImport(KeyValuePair<int, string> listKvp, bool premade = false)
             {
-                Task.Run(() => ImportArtisanList(listKvp));
+                Task.Run(() => ImportArtisanList(listKvp, premade));
             }
 
-            private bool ImportArtisanList(KeyValuePair<int, string> listKvp)
+            private bool ImportArtisanList(KeyValuePair<int, string> listKvp, bool premade)
             {
                 try
                 {
 #pragma warning disable CS8600, CS8602, CS8604, CS8605 // Null handled by catch block
                     if (TouchArtisanAssembly)
                     {
-                        System.Collections.IList artisanCraftingLists = (System.Collections.IList)ArtisanAssemblyInstance.GetFoP("Config").GetFoP("NewCraftingLists");
+                        System.Collections.IList artisanCraftingLists = GetArtisanCraftingLists(premade);
                         var   artisanRootAssembly  = Assembly.GetAssembly(ArtisanAssemblyInstance!.GetType())!;
                         var   craftingListFunctionsType = artisanRootAssembly.GetType("Artisan.CraftingLists.CraftingListFunctions")!;
                         var listMaterialsMethodInfo = craftingListFunctionsType.GetMethod("ListMaterials", All);
@@ -85,7 +103,7 @@ namespace GatherBuddy.AutoGather.Helpers
 
                         AutoGatherList list = new AutoGatherList();
                         list.Name        = listKvp.Value;
-                        list.Description = "Imported from Artisan";
+                        list.Description = premade ? "Imported from Artisan (Premade)" : "Imported from Artisan";
                         foreach (var (itemId, quantity) in matList)
                         {
                             if (!Diadem.ApprovedToRawItemIds.TryGetValue(itemId, out var mappedItemId))

--- a/GatherBuddy/Gui/Interface.AutoGatherTab.cs
+++ b/GatherBuddy/Gui/Interface.AutoGatherTab.cs
@@ -114,6 +114,7 @@ public partial class Interface
         public bool            EditDesc;
         public string          ItemFilter = string.Empty;
         public AutoGatherList? ItemFilterList;
+        public string          ArtisanImportFilter = string.Empty;
     }
 
     private readonly AutoGatherListsCache _autoGatherListsCache;
@@ -145,36 +146,65 @@ public partial class Interface
         if (GatherBuddy.AutoGather.ArtisanExporter.ArtisanAssemblyEnabled)
         {
             if (ImGuiUtil.DrawDisabledButton("Import From Artisan", Vector2.Zero,
-                    "Import your lists from Artisan into GBR\nBrings up a dropdown to select which list to import.\nA new list will be created in GBR when you click on the name of the list in the dropdown.",
+                    "Import your lists from Artisan into GBR\nBrings up a dropdown to select which list to import, from both your user lists and Artisan's premade lists.\nA new list will be created in GBR when you click on the name of the list in the dropdown.",
                     !GatherBuddy.AutoGather.ArtisanExporter.ArtisanAssemblyEnabled))
             {
+                _autoGatherListsCache.ArtisanImportFilter = string.Empty;
                 ImGui.OpenPopup($"artisanImport");
             }
 
             if (ImGui.BeginPopup($"artisanImport"))
             {
-                var lists = GatherBuddy.AutoGather.ArtisanExporter.GetArtisanListNames();
+                var filter = _autoGatherListsCache.ArtisanImportFilter;
+                List<KeyValuePair<int, string>> FilterLists(Dictionary<int, string> lists)
+                    => lists.Where(kvp => filter.Length == 0 || kvp.Value.Contains(filter, StringComparison.OrdinalIgnoreCase)).ToList();
+
+                var userLists    = FilterLists(GatherBuddy.AutoGather.ArtisanExporter.GetArtisanListNames());
+                var premadeLists = FilterLists(GatherBuddy.AutoGather.ArtisanExporter.GetArtisanListNames(true));
 
                 float rowHeight       = ImGui.GetTextLineHeightWithSpacing();
                 float childPaddingY   = ImGui.GetStyle().WindowPadding.Y * 2f;
-                float totalListHeight = lists.Count * rowHeight + childPaddingY;
-                float totalListWidth  = lists.Max(n => ImGui.CalcTextSize(n.Value).X) + 40;
+                // Two section headers with separators, plus a "None" row for each empty section.
+                int   rowCount        = Math.Max(userLists.Count, 1) + Math.Max(premadeLists.Count, 1) + 2;
+                float totalListHeight = rowCount * rowHeight + ImGui.GetStyle().ItemSpacing.Y * 2 + childPaddingY;
+                float totalListWidth  = userLists.Concat(premadeLists)
+                        .Select(n => ImGui.CalcTextSize(n.Value).X)
+                        .DefaultIfEmpty(ImGui.CalcTextSize("Premade Lists").X)
+                        .Max()
+                    + 40;
 
                 float maxHeight   = ImGui.GetIO().DisplaySize.Y * 0.4f;
                 float childHeight = Math.Min(totalListHeight, maxHeight);
 
-                if (ImGui.BeginChild("ArtisanListsChild", new Vector2(totalListWidth, childHeight), true))
+                ImGui.SetNextItemWidth(totalListWidth);
+                ImGui.InputTextWithHint("##artisanImportFilter", "Filter...", ref _autoGatherListsCache.ArtisanImportFilter, 128);
+
+                void DrawSection(string header, List<KeyValuePair<int, string>> lists, bool premade)
                 {
+                    ImGui.TextDisabled(header);
+                    ImGui.Separator();
+                    if (lists.Count == 0)
+                    {
+                        ImGui.TextDisabled("None");
+                        return;
+                    }
+
                     foreach (var kvp in lists)
                     {
-                        if (ImGui.Selectable($"{kvp.Value}##{kvp.Key}"))
+                        if (ImGui.Selectable($"{kvp.Value}##{(premade ? "premade" : "user")}{kvp.Key}"))
                         {
                             Communicator.Print($"Importing '{kvp.Value}' from Artisan...");
-                            GatherBuddy.AutoGather.ArtisanExporter.StartArtisanImport(kvp);
+                            GatherBuddy.AutoGather.ArtisanExporter.StartArtisanImport(kvp, premade);
                         }
 
                         ImGuiUtil.HoverTooltip($"{kvp.Value} ({kvp.Key})\n(Click to import to new auto-gather list)");
                     }
+                }
+
+                if (ImGui.BeginChild("ArtisanListsChild", new Vector2(totalListWidth, childHeight), true))
+                {
+                    DrawSection("User Lists",    userLists,    false);
+                    DrawSection("Premade Lists", premadeLists, true);
                 }
 
                 ImGui.EndChild();


### PR DESCRIPTION
## What

The Auto-Gather tab's "Import From Artisan" popup previously only listed Artisan **user lists** (`Config.NewCraftingLists`). Artisan's quest-derived **premade lists** live in a separate collection (`PremadeLists.PremadeCraftingLists`) of the same `NewCraftingList` type, so they can be imported through the exact same reflection + `ListMaterials` path. The popup now shows two labeled sections — User Lists and Premade Lists — plus a filter box (there are 80+ premade lists).

## Disclosure

Being up front: I'm not a software developer, and this change was written with Claude (Fable 5, high reasoning effort) driving the code analysis and implementation. I tested it in-game myself (details below). Happy to make any changes requested — please don't hesitate to point out anything that doesn't fit the codebase's conventions.

## Implementation notes

- Lookups stay per-collection rather than merged: user list IDs are random ints while premade IDs are quest RowIds, so a merged dictionary could collide. ImGui selectable IDs are namespaced per section (`##user{id}` / `##premade{id}`) for the same reason.
- Premade imports are described as "Imported from Artisan (Premade)" to distinguish provenance.
- The premade collection resolution is null-guarded, so an Artisan version without `PremadeLists` degrades to an empty section instead of erroring.
- Fixes a latent crash in passing: the old popup width calculation called `.Max()` directly on the list collection, which throws `InvalidOperationException` if a user has zero Artisan lists.

## Testing

Built against Dalamud 15.0.2 / Artisan v4.0.5.16 and tested in-game as a dev plugin:

- Both sections render and filter correctly (user lists + 80+ quest premades).
- Importing a user list behaves identically to before.
- Importing a premade list ("Carpenter Quests - A Carpenter in Need - Lv.15") produced a correct auto-gather list (10 gatherable items with right quantities; non-gatherable mats skipped per existing behavior).
- No errors in `/xllog` during either import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
