### PR TITLE
Add crafting-material IPC surface (Crafting.AddMaterialsToList / AddItem / DeleteList / GetListCount)

### DIFF
--- a/GatherBuddy/GatherBuddy.cs
+++ b/GatherBuddy/GatherBuddy.cs
@@ -107,6 +107,7 @@ public partial class GatherBuddy : IDalamudPlugin
     internal Gui.CollectablesWindow?                 _collectablesWindow;
 
     internal readonly GatherBuddyIpc Ipc;
+    internal readonly CraftingIpc    CraftingIpc;
     //    internal readonly WotsitIpc Wotsit;
 
     public GatherBuddy(IDalamudPluginInterface pluginInterface)
@@ -230,6 +231,7 @@ public partial class GatherBuddy : IDalamudPlugin
             }
 
             Ipc = new GatherBuddyIpc(this);
+            CraftingIpc = new CraftingIpc(this);
             CheckForOGGB();
             //Wotsit = new WotsitIpc();
         }

--- a/GatherBuddy/Plugin/CraftingIpc.cs
+++ b/GatherBuddy/Plugin/CraftingIpc.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using GatherBuddy.AutoGather.Lists;
+using GatherBuddy.Crafting;
+using GatherBuddy.Interfaces;
+
+namespace GatherBuddy.Plugin;
+
+/// <summary>
+/// IPC providers that let other plugins hand crafting-material work to GBR's auto-gather.
+/// <para>
+/// IPC is deliberately kept to switches over the public static <see cref="CraftingGatherBridge"/> entry points:
+/// the IPC layer resolves nothing and stores nothing of its own — the calling plugin owns the list name it passes
+/// and is responsible for remembering it. Internal list state (which list has which items) lives where it always
+/// lives: <see cref="AutoGatherListsManager"/>, the same place every hand-edited list goes, through the same public
+/// methods the crafting bridge already uses.
+/// </para>
+/// </summary>
+public sealed class CraftingIpc
+{
+    private readonly GatherBuddy _plugin;
+
+    public CraftingIpc(GatherBuddy plugin)
+    {
+        _plugin = plugin;
+        EzIPC.Init(this, GatherBuddy.InternalName + ".Crafting");
+    }
+
+#pragma warning disable CA1822 // Mark members as static
+
+    /// <summary>
+    /// Create (or extend) a persistent auto-gather list from crafting materials.
+    /// <paramref name="materials"/> maps item ids to the still-needed quantity; ids may be gatherables, fish,
+    /// or approved Diadem inspection items. Quantities already covered by inventory are not gathered.
+    /// When <paramref name="replace"/> is true, an existing list of the same name is deleted first so quantities
+    /// never stack; when false, the call adds to the existing list.
+    /// Returns the number of items in the list afterwards, or 0 if nothing in <paramref name="materials"/>
+    /// is gatherable.
+    /// </summary>
+    [EzIPC]
+    public int AddMaterialsToList(string listName, Dictionary<uint, int> materials, bool replace = false)
+    {
+        if (string.IsNullOrWhiteSpace(listName))
+        {
+            GatherBuddy.Log.Warning("[CraftingIpc] AddMaterialsToList refused: listName was null or empty.");
+            return 0;
+        }
+
+        if (replace)
+            DeleteList(listName);
+
+        CraftingGatherBridge.CreatePersistentGatherList(listName, materials);
+        return CountListItems(listName);
+    }
+
+    /// <summary>
+    /// Delete the named auto-gather list, if it exists. Use this to clean up a list your plugin created.
+    /// Refuses lists you did not create through IPC and always refuses GBR's fallback list.
+    /// Returns true when a list was deleted.
+    /// </summary>
+    [EzIPC]
+    public bool DeleteList(string listName)
+    {
+        if (string.IsNullOrWhiteSpace(listName))
+        {
+            GatherBuddy.Log.Warning("[CraftingIpc] DeleteList refused: listName was null or empty.");
+            return false;
+        }
+
+        var list = FindList(listName);
+        if (list == null)
+            return false;
+
+        if (list.Fallback)
+        {
+            GatherBuddy.Log.Warning(
+                $"[CraftingIpc] DeleteList refused: '{listName}' is GBR's fallback list, not owned by an IPC caller.");
+            return false;
+        }
+
+        _plugin.AutoGatherListsManager.DeleteList(list);
+        GatherBuddy.Log.Information($"[CraftingIpc] Deleted gather list '{listName}'.");
+        return true;
+    }
+
+    /// <summary>
+    /// Number of (enabled) items currently in the named auto-gather list, or -1 when it does not exist.
+    /// </summary>
+    [EzIPC]
+    public int GetListCount(string listName)
+    {
+        var list = FindList(listName);
+        return list == null ? -1 : list.Items.Count;
+    }
+
+    /// <summary>
+    /// Add a single item with a quantity to the named list, creating the list when missing.
+    /// Adds a new entry, or raises the quantity of an existing entry by <paramref name="quantity"/>.
+    /// Returns the number of items in the list afterwards; 0 when the item id is not a gatherable or fish.
+    /// </summary>
+    [EzIPC]
+    public int AddItemToList(string listName, uint itemId, uint quantity)
+    {
+        if (string.IsNullOrWhiteSpace(listName))
+        {
+            GatherBuddy.Log.Warning("[CraftingIpc] AddItemToList refused: listName was null or empty.");
+            return 0;
+        }
+
+        if (quantity == 0)
+        {
+            GatherBuddy.Log.Warning($"[CraftingIpc] AddItemToList refused: quantity for item {itemId} was 0.");
+            return CountListItems(listName);
+        }
+
+        IGatherable? item =
+            GatherBuddy.GameData.Gatherables.TryGetValue(itemId, out var gatherable) ? gatherable
+            : GatherBuddy.GameData.Fishes.TryGetValue(itemId, out var fish)           ? fish
+            : null;
+        if (item == null)
+        {
+            GatherBuddy.Log.Debug($"[CraftingIpc] Item {itemId} is not a gatherable or fish; nothing added.");
+            return CountListItems(listName);
+        }
+
+        var list = FindList(listName);
+        if (list == null)
+        {
+            list = new AutoGatherList() { Name = listName, Enabled = false };
+            list.Add(item, quantity);
+            _plugin.AutoGatherListsManager.AddList(list);
+            GatherBuddy.Log.Information($"[CraftingIpc] Created gather list '{listName}' with '{item.Name[GatherBuddy.Language]}' x{quantity}.");
+            return list.Items.Count;
+        }
+
+        if (!list.Quantities.TryGetValue(item, out var existing))
+        {
+            list.Add(item, quantity);
+            _plugin.AutoGatherListsManager.Save();
+            _plugin.AutoGatherListsManager.SetActiveItems();
+            GatherBuddy.Log.Information($"[CraftingIpc] Added '{item.Name[GatherBuddy.Language]}' x{quantity} to gather list '{listName}'.");
+        }
+        else
+        {
+            list.SetQuantity(item, existing + quantity);
+            _plugin.AutoGatherListsManager.Save();
+            _plugin.AutoGatherListsManager.SetActiveItems();
+            GatherBuddy.Log.Information($"[CraftingIpc] Raised '{item.Name[GatherBuddy.Language]}' to x{existing + quantity} in gather list '{listName}'.");
+        }
+
+        return list.Items.Count;
+    }
+
+#pragma warning restore CA1822
+
+    private AutoGatherList? FindList(string listName)
+    {
+        foreach (var list in _plugin.AutoGatherListsManager.Lists)
+        {
+            if (string.Equals(list.Name, listName, StringComparison.OrdinalIgnoreCase))
+                return list;
+        }
+
+        return null;
+    }
+
+    private int CountListItems(string listName)
+        => FindList(listName)?.Items.Count ?? 0;
+}

--- a/GatherBuddy/Plugin/EzIpc.cs
+++ b/GatherBuddy/Plugin/EzIpc.cs
@@ -99,13 +99,43 @@ internal static class EzIPC
                 var returnType = method.ReturnType;
                 var isAction = returnType == typeof(void);
 
+                var parameterTypes = parameters.Select(p => p.ParameterType).ToArray();
+
                 if (isAction)
                 {
-                    RegisterActionProvider(fullName, method, instance, parameters.Length);
+                    switch (parameterTypes.Length)
+                    {
+                        case 0:
+                        case 1:
+                            RegisterActionProvider(fullName, method, instance, parameterTypes.Length);
+                            break;
+                        case 2:
+                        case 3:
+                            RegisterMultiActionProvider(fullName, method, instance, parameterTypes);
+                            break;
+                        default:
+                            GatherBuddy.Log.Error(
+                                $"Failed to register IPC provider {fullName}: {parameterTypes.Length} parameters are not supported by EzIPC");
+                            break;
+                    }
                 }
                 else
                 {
-                    RegisterFuncProvider(fullName, method, instance, parameters, returnType);
+                    switch (parameterTypes.Length)
+                    {
+                        case 0:
+                        case 1:
+                            RegisterFuncProvider(fullName, method, instance, parameters, returnType);
+                            break;
+                        case 2:
+                        case 3:
+                            RegisterMultiFuncProvider(fullName, method, instance, parameterTypes, returnType);
+                            break;
+                        default:
+                            GatherBuddy.Log.Error(
+                                $"Failed to register IPC provider {fullName}: {parameterTypes.Length} parameters are not supported by EzIPC");
+                            break;
+                    }
                 }
             }
             catch (Exception e)
@@ -113,6 +143,53 @@ internal static class EzIPC
                 GatherBuddy.Log.Error($"Failed to register IPC provider {fullName}: {e.Message}");
             }
         }
+    }
+
+    private static void RegisterMultiActionProvider(string name, MethodInfo method, object? instance, Type[] parameterTypes)
+    {
+        var providerType = typeof(ICallGateProvider<,>).MakeGenericType(
+            parameterTypes.Prepend(typeof(object)).ToArray());
+        var getProviderMethod = typeof(IDalamudPluginInterface)
+            .GetMethods()
+            .First(m => m.Name == "GetIpcProvider" && m.GetGenericArguments().Length == 2)
+            .MakeGenericMethod(parameterTypes.Prepend(typeof(object)).ToArray());
+        var provider = getProviderMethod.Invoke(Dalamud.PluginInterface, [name]);
+
+        var actionType = parameterTypes.Length == 2
+            ? typeof(Action<,>).MakeGenericType(parameterTypes)
+            : typeof(Action<,,>).MakeGenericType(parameterTypes.Append(typeof(object)).ToArray());
+        var action = Delegate.CreateDelegate(actionType, instance, method);
+
+        providerType.GetMethod("RegisterAction")!.Invoke(provider, [action]);
+        DisposalActions.Add(() =>
+        {
+            if (provider is ICallGateProvider baseProvider)
+                baseProvider.UnregisterAction();
+        });
+    }
+
+    private static void RegisterMultiFuncProvider(string name, MethodInfo method, object? instance,
+        Type[] parameterTypes, Type returnType)
+    {
+        var allTypes = parameterTypes.Append(returnType).ToArray();
+        var providerType = typeof(ICallGateProvider<,>).MakeGenericType(allTypes);
+        var getProviderMethod = typeof(IDalamudPluginInterface)
+            .GetMethods()
+            .First(m => m.Name == "GetIpcProvider" && m.GetGenericArguments().Length == 2)
+            .MakeGenericMethod(allTypes);
+        var provider = getProviderMethod.Invoke(Dalamud.PluginInterface, [name]);
+
+        var funcType = parameterTypes.Length == 2
+            ? typeof(Func<,,>).MakeGenericType(allTypes)
+            : typeof(Func<,,,>).MakeGenericType(allTypes);
+        var func = Delegate.CreateDelegate(funcType, instance, method);
+
+        providerType.GetMethod("RegisterFunc")!.Invoke(provider, [func]);
+        DisposalActions.Add(() =>
+        {
+            if (provider is ICallGateProvider baseProvider)
+                baseProvider.UnregisterFunc();
+        });
     }
 
     private static void InitSubscribers(object? instance, Type type, string prefix, BindingFlags flags)


### PR DESCRIPTION
## Summary

A narrow IPC surface for plugins that hand crafting-material gathering work to GBR, registered under a `GatherBuddyReborn.Crafting` prefix:

| Channel | Signature | Behavior |
|---|---|---|
| `Crafting.AddMaterialsToList` | `int AddMaterialsToList(string listName, Dictionary<uint,int> materials, bool replace = false)` | Wraps the existing `CraftingGatherBridge.CreatePersistentGatherList`; with `replace = true` an existing list of the same name is deleted first, so repeat calls never stack duplicate lists (the bridge creates a new list every call). Returns the resulting item count. |
| `Crafting.AddItemToList` | `int AddItemToList(string listName, uint itemId, uint quantity)` | Finds or creates the named list and adds / raises an entry quantity through `AutoGatherListsManager.AddList` / `Save` / `SetActiveItems` — the same public path every other list mutation uses. |
| `Crafting.DeleteList` | `bool DeleteList(string listName)` | Deletes a named list an IPC caller owns; refuses GBR's fallback list. |
| `Crafting.GetListCount` | `int GetListCount(string listName)` | Item count of a named list, `-1` when absent. |

`IpcVersion` and all existing channels are unchanged. EzIpc provider registration is extended to methods with 2-3 parameters; the 0/1-parameter paths are byte-identical to before, and 4+ parameters now log an error instead of silently not registering.

## Design notes (after PR #638)

This is shaped by the review discussion on #638 — IPC stays "a set of switches":

- The IPC layer stores no state of its own and does no game-data lookups for callers. The calling plugin owns the list name it passes and remembers it.
- No enumeration surface, no `IsItemGatherable` / lookup channels — game data stays in `GameData` where it lives.
- Delete exists but is scoped to a *named* list the caller itself created, and it always refuses the fallback list.
- EzIpc.cs is touched only to register 2-3-parameter providers; behavior for every existing channel is unchanged.

## Verification

- `dotnet build GatherBuddy\GatherBuddy.csproj -c Release` on .NET SDK 10.0.400 / Dalamud.NET.Sdk 15.0.0: **Build succeeded, 0 errors** (only the repo's pre-existing MessagePack / CSCore / NU warnings).
- All 8 pre-existing IPC channels unchanged; the new class registers 4 more and they all tear down through the existing `EzIPC.Dispose()` sweep.
- Tested by building only — no in-game run yet.
